### PR TITLE
Init pwd

### DIFF
--- a/pkg/management/component.go
+++ b/pkg/management/component.go
@@ -474,8 +474,8 @@ func (c *component) ResetPassword(ctx context.Context, realmName string, userID 
 	}
 
 	//store the API call into the DB
-	// the error should be treated
-	_ = c.reportEvent(ctx, "INIT_PASSWORD", database.CtEventRealmName, realmName, database.CtEventUserID, userID)
+	//_ = c.reportEvent(ctx, "INIT_PASSWORD", database.CtEventRealmName, realmName, database.CtEventUserID, userID)
+	// removed as it is not used
 
 	return nil
 }
@@ -490,9 +490,14 @@ func (c *component) ExecuteActionsEmail(ctx context.Context, realmName string, u
 	var accessToken = ctx.Value(cs.CtContextAccessToken).(string)
 
 	var actions = []string{}
+	var init_password_action = "sms-password-set"
 
 	for _, requiredAction := range requiredActions {
 		actions = append(actions, string(requiredAction))
+		if string(requiredAction) == init_password_action {
+			//store the API call into the DB
+			_ = c.reportEvent(ctx, "INIT_PASSWORD", database.CtEventRealmName, realmName, database.CtEventUserID, userID)
+		}
 	}
 
 	return c.keycloakClient.ExecuteActionsEmail(accessToken, realmName, userID, actions, paramKV...)

--- a/pkg/management/component.go
+++ b/pkg/management/component.go
@@ -13,6 +13,10 @@ import (
 	kc "github.com/cloudtrust/keycloak-client"
 )
 
+const (
+	initPasswordAction = "sms-password-set"
+)
+
 // KeycloakClient are methods from keycloak-client used by this component
 type KeycloakClient interface {
 	GetRealms(accessToken string) ([]kc.RealmRepresentation, error)
@@ -490,7 +494,6 @@ func (c *component) ExecuteActionsEmail(ctx context.Context, realmName string, u
 	var accessToken = ctx.Value(cs.CtContextAccessToken).(string)
 
 	var actions = []string{}
-	var initPasswordAction = "sms-password-set"
 
 	for _, requiredAction := range requiredActions {
 		actions = append(actions, string(requiredAction))

--- a/pkg/management/component.go
+++ b/pkg/management/component.go
@@ -490,11 +490,11 @@ func (c *component) ExecuteActionsEmail(ctx context.Context, realmName string, u
 	var accessToken = ctx.Value(cs.CtContextAccessToken).(string)
 
 	var actions = []string{}
-	var init_password_action = "sms-password-set"
+	var initPasswordAction = "sms-password-set"
 
 	for _, requiredAction := range requiredActions {
 		actions = append(actions, string(requiredAction))
-		if string(requiredAction) == init_password_action {
+		if string(requiredAction) == initPasswordAction {
 			//store the API call into the DB
 			_ = c.reportEvent(ctx, "INIT_PASSWORD", database.CtEventRealmName, realmName, database.CtEventUserID, userID)
 		}

--- a/pkg/management/component.go
+++ b/pkg/management/component.go
@@ -478,8 +478,7 @@ func (c *component) ResetPassword(ctx context.Context, realmName string, userID 
 	}
 
 	//store the API call into the DB
-	//_ = c.reportEvent(ctx, "INIT_PASSWORD", database.CtEventRealmName, realmName, database.CtEventUserID, userID)
-	// removed as it is not used
+	_ = c.reportEvent(ctx, "INIT_PASSWORD", database.CtEventRealmName, realmName, database.CtEventUserID, userID)
 
 	return nil
 }

--- a/pkg/management/component_test.go
+++ b/pkg/management/component_test.go
@@ -1281,8 +1281,8 @@ func TestExecuteActionsEmail(t *testing.T) {
 	var accessToken = "TOKEN=="
 	var realmName = "master"
 	var userID = "1245-7854-8963"
-	var reqActions = []api.RequiredAction{"sms-password-set", "action1", "action2"}
-	var actions = []string{"sms-password-set", "action1", "action2"}
+	var reqActions = []api.RequiredAction{initPasswordAction, "action1", "action2"}
+	var actions = []string{initPasswordAction, "action1", "action2"}
 
 	var key1 = "key1"
 	var value1 = "value1"

--- a/pkg/management/component_test.go
+++ b/pkg/management/component_test.go
@@ -1295,7 +1295,7 @@ func TestExecuteActionsEmail(t *testing.T) {
 		mockKeycloakClient.EXPECT().ExecuteActionsEmail(accessToken, realmName, userID, actions, key1, value1, key2, value2).Return(nil).Times(1)
 
 		var ctx = context.WithValue(context.Background(), cs.CtContextAccessToken, accessToken)
-		mockEventDBModule.EXPECT().ReportEvent(ctx, "INIT_PASSWORD", "back-office", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockEventDBModule.EXPECT().ReportEvent(ctx, "INIT_PASSWORD", "back-office", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
 		err := managementComponent.ExecuteActionsEmail(ctx, "master", userID, reqActions, key1, value1, key2, value2)
 

--- a/pkg/management/component_test.go
+++ b/pkg/management/component_test.go
@@ -1281,8 +1281,8 @@ func TestExecuteActionsEmail(t *testing.T) {
 	var accessToken = "TOKEN=="
 	var realmName = "master"
 	var userID = "1245-7854-8963"
-	var reqActions = []api.RequiredAction{"action1", "action2"}
-	var actions = []string{"action1", "action2"}
+	var reqActions = []api.RequiredAction{"sms-password-set", "action1", "action2"}
+	var actions = []string{"sms-password-set", "action1", "action2"}
 
 	var key1 = "key1"
 	var value1 = "value1"
@@ -1291,9 +1291,11 @@ func TestExecuteActionsEmail(t *testing.T) {
 
 	// Send email actions
 	{
+
 		mockKeycloakClient.EXPECT().ExecuteActionsEmail(accessToken, realmName, userID, actions, key1, value1, key2, value2).Return(nil).Times(1)
 
 		var ctx = context.WithValue(context.Background(), cs.CtContextAccessToken, accessToken)
+		mockEventDBModule.EXPECT().ReportEvent(ctx, "INIT_PASSWORD", "back-office", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 		err := managementComponent.ExecuteActionsEmail(ctx, "master", userID, reqActions, key1, value1, key2, value2)
 


### PR DESCRIPTION
added INIT_PASSWORD event when a support user calls the API execute-actions-email with the action sms-password-set