### PR TITLE
Send reminder email

### DIFF
--- a/cmd/keycloakb/keycloak_bridge.go
+++ b/cmd/keycloakb/keycloak_bridge.go
@@ -408,6 +408,7 @@ func main() {
 			ResetPassword:                  prepareEndpoint(management.MakeResetPasswordEndpoint(keycloakComponent), "reset_password_endpoint", influxMetrics, managementLogger, tracer, rateLimit["management"]),
 			SendVerifyEmail:                prepareEndpoint(management.MakeSendVerifyEmailEndpoint(keycloakComponent), "send_verify_email_endpoint", influxMetrics, managementLogger, tracer, rateLimit["management"]),
 			ExecuteActionsEmail:            prepareEndpoint(management.MakeExecuteActionsEmailEndpoint(keycloakComponent), "execute_actions_email_endpoint", influxMetrics, managementLogger, tracer, rateLimit["management"]),
+			SendReminderEmail:              prepareEndpoint(management.MakeSendReminderEmailEndpoint(keycloakComponent), "send_reminder_email_endpoint", influxMetrics, managementLogger, tracer, rateLimit["management"]),
 			SendNewEnrolmentCode:           prepareEndpoint(management.MakeSendNewEnrolmentCodeEndpoint(keycloakComponent), "send_new_enrolment_code_endpoint", influxMetrics, managementLogger, tracer, rateLimit["management"]),
 			GetCredentialsForUser:          prepareEndpoint(management.MakeGetCredentialsForUserEndpoint(keycloakComponent), "get_credentials_for_user_endpoint", influxMetrics, managementLogger, tracer, rateLimit["management"]),
 			DeleteCredentialsForUser:       prepareEndpoint(management.MakeDeleteCredentialsForUserEndpoint(keycloakComponent), "delete_credentials_for_user_endpoint", influxMetrics, managementLogger, tracer, rateLimit["management"]),

--- a/cmd/keycloakb/keycloak_bridge.go
+++ b/cmd/keycloakb/keycloak_bridge.go
@@ -534,6 +534,7 @@ func main() {
 		var sendVerifyEmailHandler = configureManagementHandler(ComponentName, ComponentID, idGenerator, keycloakClient, audienceRequired, tracer, logger)(managementEndpoints.SendVerifyEmail)
 		var executeActionsEmailHandler = configureManagementHandler(ComponentName, ComponentID, idGenerator, keycloakClient, audienceRequired, tracer, logger)(managementEndpoints.ExecuteActionsEmail)
 		var sendNewEnrolmentCodeHandler = configureManagementHandler(ComponentName, ComponentID, idGenerator, keycloakClient, audienceRequired, tracer, logger)(managementEndpoints.SendNewEnrolmentCode)
+		var sendReminderEmailHandler = configureManagementHandler(ComponentName, ComponentID, idGenerator, keycloakClient, audienceRequired, tracer, logger)(managementEndpoints.SendReminderEmail)
 
 		var getCredentialsForUserHandler = configureManagementHandler(ComponentName, ComponentID, idGenerator, keycloakClient, audienceRequired, tracer, logger)(managementEndpoints.GetCredentialsForUser)
 		var deleteCredentialsForUserHandler = configureManagementHandler(ComponentName, ComponentID, idGenerator, keycloakClient, audienceRequired, tracer, logger)(managementEndpoints.DeleteCredentialsForUser)
@@ -567,6 +568,7 @@ func main() {
 		managementSubroute.Path("/realms/{realm}/users/{userID}/send-verify-email").Methods("PUT").Handler(sendVerifyEmailHandler)
 		managementSubroute.Path("/realms/{realm}/users/{userID}/execute-actions-email").Methods("PUT").Handler(executeActionsEmailHandler)
 		managementSubroute.Path("/realms/{realm}/users/{userID}/send-new-enrolment-code").Methods("POST").Handler(sendNewEnrolmentCodeHandler)
+		managementSubroute.Path("/realms/{realm}/users/{userID}/send-reminder-email").Methods("POST").Handler(sendReminderEmailHandler)
 
 		// Credentials
 		managementSubroute.Path("/realms/{realm}/users/{userID}/credentials").Methods("GET").Handler(getCredentialsForUserHandler)

--- a/configs/authorization.json
+++ b/configs/authorization.json
@@ -72,6 +72,13 @@
           "l3_support_manager": {}
         }
       },
+      "SendReminderEmail": {
+        "master": {
+          "integrator_manager": {},
+          "l2_support_manager": {},
+          "l3_support_manager": {}
+        }
+      },
       "GetCredentialsForUser": {
         "master": {
           "*": {}
@@ -197,6 +204,14 @@
           "end_user": {}
         }
       },
+      "SendReminderEmail": {
+        "master": {
+          "integrator_agent": {}
+        },
+        "DEP": {
+          "end_user": {}
+        }
+      },
       "GetCredentialsForUser": {
         "master": {
           "integrator_agent": {}
@@ -306,6 +321,11 @@
           "*": {}
         }
       },
+      "SendReminderEmail": {
+        "DEP": {
+          "*": {}
+        }
+      },
       "GetCredentialsForUser": {
         "DEP": {
           "*": {}
@@ -402,6 +422,11 @@
         }
       },
       "ExecuteActionsEmail": {
+        "master": {
+          "l2_support_agent": {}
+        }
+      },
+      "SendReminderEmail": {
         "master": {
           "l2_support_agent": {}
         }
@@ -517,6 +542,11 @@
         }
       },
       "ExecuteActionsEmail": {
+        "master": {
+          "l3_support_agent": {}
+        }
+      },
+      "SendReminderEmail": {
         "master": {
           "l3_support_agent": {}
         }
@@ -638,6 +668,11 @@
           "*": {}
         }
       },
+      "SendReminderEmail": {
+        "DEP": {
+          "*": {}
+        }
+      },
       "SendNewEnrolmentCode":{
         "DEP": {
           "end_user": {}
@@ -737,6 +772,12 @@
           "end_user": {}
         }
       },
+      "SendReminderEmail": {
+        "DEP": {
+          "l1_support_agent": {},
+          "end_user": {}
+        }
+      },
       "GetCredentialsForUser": {
         "DEP": {
           "l1_support_agent": {},
@@ -817,6 +858,11 @@
           "end_user": {}
         }
       },
+      "SendReminderEmail": {
+        "DEP": {
+          "end_user": {}
+        }
+      },
       "GetCredentialsForUser": {
         "DEP": {
           "end_user": {}
@@ -845,6 +891,11 @@
         }
       },
       "SendVerifyEmail": {
+        "DEP": {
+          "end_user": {}
+        }
+      },
+      "SendReminderEmail": {
         "DEP": {
           "end_user": {}
         }

--- a/pkg/management/authorization.go
+++ b/pkg/management/authorization.go
@@ -28,6 +28,7 @@ const (
 	SendVerifyEmail                = "SendVerifyEmail"
 	ExecuteActionsEmail            = "ExecuteActionsEmail"
 	SendNewEnrolmentCode           = "SendNewEnrolmentCode"
+	SendReminderEmail              = "SendReminderEmail"
 	GetCredentialsForUser          = "GetCredentialsForUser"
 	DeleteCredentialsForUser       = "DeleteCredentialsForUser"
 	GetRoles                       = "GetRoles"
@@ -258,6 +259,17 @@ func (c *authorizationComponentMW) SendNewEnrolmentCode(ctx context.Context, rea
 	}
 
 	return c.next.SendNewEnrolmentCode(ctx, realmName, userID)
+}
+
+func (c *authorizationComponentMW) SendReminderEmail(ctx context.Context, realmName string, userID string, paramKV ...string) error {
+	var action = SendReminderEmail
+	var targetRealm = realmName
+
+	if err := c.authManager.CheckAuthorizationOnTargetUser(ctx, action, targetRealm, userID); err != nil {
+		return err
+	}
+
+	return c.next.SendReminderEmail(ctx, realmName, userID, paramKV...)
 }
 
 func (c *authorizationComponentMW) GetCredentialsForUser(ctx context.Context, realmName string, userID string) ([]api.CredentialRepresentation, error) {

--- a/pkg/management/authorization_test.go
+++ b/pkg/management/authorization_test.go
@@ -133,6 +133,9 @@ func TestDeny(t *testing.T) {
 		_, err = authorizationMW.SendNewEnrolmentCode(ctx, realmName, userID)
 		assert.Equal(t, security.ForbiddenError{}, err)
 
+		err = authorizationMW.SendReminderEmail(ctx, realmName, userID)
+		assert.Equal(t, security.ForbiddenError{}, err)
+
 		_, err = authorizationMW.GetCredentialsForUser(ctx, realmName, userID)
 		assert.Equal(t, security.ForbiddenError{}, err)
 
@@ -235,6 +238,7 @@ func TestAllowed(t *testing.T) {
 					"SendVerifyEmail": {"*": {"*": {} }},
 					"ExecuteActionsEmail": {"*": {"*": {} }},
 					"SendNewEnrolmentCode": {"*": {"*": {} }},
+					"SendReminderEmail": {"*": {"*": {} }},
 					"GetCredentialsForUser": {"*": {"*": {} }},
 					"DeleteCredentialsForUser": {"*": {"*": {} }},
 					"GetRoles": {"*": {"*": {} }},
@@ -327,6 +331,10 @@ func TestAllowed(t *testing.T) {
 
 		mockManagementComponent.EXPECT().SendNewEnrolmentCode(ctx, realmName, userID).Return("1234", nil).Times(1)
 		_, err = authorizationMW.SendNewEnrolmentCode(ctx, realmName, userID)
+		assert.Nil(t, err)
+
+		mockManagementComponent.EXPECT().SendReminderEmail(ctx, realmName, userID).Return(nil).Times(1)
+		err = authorizationMW.SendReminderEmail(ctx, realmName, userID)
 		assert.Nil(t, err)
 
 		mockManagementComponent.EXPECT().GetCredentialsForUser(ctx, realmName, userID).Return([]api.CredentialRepresentation{}, nil).Times(1)

--- a/pkg/management/component.go
+++ b/pkg/management/component.go
@@ -32,6 +32,7 @@ type KeycloakClient interface {
 	SendVerifyEmail(accessToken string, realmName string, userID string, paramKV ...string) error
 	ExecuteActionsEmail(accessToken string, realmName string, userID string, actions []string, paramKV ...string) error
 	SendNewEnrolmentCode(accessToken string, realmName string, userID string) (kc.SmsCodeRepresentation, error)
+	SendReminderEmail(accessToken string, realmName string, userID string, paramKV ...string) error
 	GetCredentialsForUser(accessToken string, realmReq, realmName string, userID string) ([]kc.CredentialRepresentation, error)
 	DeleteCredentialsForUser(accessToken string, realmReq, realmName string, userID string, credentialID string) error
 	GetRoles(accessToken string, realmName string) ([]kc.RoleRepresentation, error)
@@ -62,6 +63,7 @@ type Component interface {
 	SendVerifyEmail(ctx context.Context, realmName string, userID string, paramKV ...string) error
 	ExecuteActionsEmail(ctx context.Context, realmName string, userID string, actions []api.RequiredAction, paramKV ...string) error
 	SendNewEnrolmentCode(ctx context.Context, realmName string, userID string) (string, error)
+	SendReminderEmail(ctx context.Context, realmName string, userID string, paramKV ...string) error
 	GetCredentialsForUser(ctx context.Context, realmName string, userID string) ([]api.CredentialRepresentation, error)
 	DeleteCredentialsForUser(ctx context.Context, realmName string, userID string, credentialID string) error
 	GetRoles(ctx context.Context, realmName string) ([]api.RoleRepresentation, error)
@@ -511,6 +513,12 @@ func (c *component) SendNewEnrolmentCode(ctx context.Context, realmName string, 
 	_ = c.reportEvent(ctx, "SMS_CHALLENGE", "realm_name", realmName, "user_id", userID)
 
 	return *smsCodeKc.Code, err
+}
+
+func (c *component) SendReminderEmail(ctx context.Context, realmName string, userID string, paramKV ...string) error {
+	var accessToken = ctx.Value(cs.CtContextAccessToken).(string)
+
+	return c.keycloakClient.SendVerifyEmail(accessToken, realmName, userID, paramKV...)
 }
 
 func (c *component) GetCredentialsForUser(ctx context.Context, realmName string, userID string) ([]api.CredentialRepresentation, error) {

--- a/pkg/management/component.go
+++ b/pkg/management/component.go
@@ -518,7 +518,7 @@ func (c *component) SendNewEnrolmentCode(ctx context.Context, realmName string, 
 func (c *component) SendReminderEmail(ctx context.Context, realmName string, userID string, paramKV ...string) error {
 	var accessToken = ctx.Value(cs.CtContextAccessToken).(string)
 
-	return c.keycloakClient.SendVerifyEmail(accessToken, realmName, userID, paramKV...)
+	return c.keycloakClient.SendReminderEmail(accessToken, realmName, userID, paramKV...)
 }
 
 func (c *component) GetCredentialsForUser(ctx context.Context, realmName string, userID string) ([]api.CredentialRepresentation, error) {

--- a/pkg/management/component_test.go
+++ b/pkg/management/component_test.go
@@ -1352,6 +1352,50 @@ func TestSendNewEnrolmentCode(t *testing.T) {
 	}
 }
 
+func TestSendReminderEmail(t *testing.T) {
+	var mockCtrl = gomock.NewController(t)
+	defer mockCtrl.Finish()
+	var mockKeycloakClient = mock.NewKeycloakClient(mockCtrl)
+	var mockEventDBModule = mock.NewEventDBModule(mockCtrl)
+	var mockConfigurationDBModule = mock.NewConfigurationDBModule(mockCtrl)
+
+	var managementComponent = NewComponent(mockKeycloakClient, mockEventDBModule, mockConfigurationDBModule)
+
+	var accessToken = "TOKEN=="
+	var realmName = "master"
+	var userID = "1245-7854-8963"
+
+	var key1 = "key1"
+	var value1 = "value1"
+	var key2 = "key2"
+	var value2 = "value2"
+	var key3 = "key3"
+	var value3 = "value3"
+
+	// Send email
+	{
+
+		mockKeycloakClient.EXPECT().SendReminderEmail(accessToken, realmName, userID, key1, value1, key2, value2, key3, value3).Return(nil).Times(1)
+
+		var ctx = context.WithValue(context.Background(), cs.CtContextAccessToken, accessToken)
+
+		err := managementComponent.SendReminderEmail(ctx, "master", userID, key1, value1, key2, value2, key3, value3)
+
+		assert.Nil(t, err)
+	}
+
+	// Error
+	{
+		mockKeycloakClient.EXPECT().SendReminderEmail(accessToken, realmName, userID).Return(fmt.Errorf("Invalid input")).Times(1)
+
+		var ctx = context.WithValue(context.Background(), cs.CtContextAccessToken, accessToken)
+
+		err := managementComponent.SendReminderEmail(ctx, "master", userID)
+
+		assert.NotNil(t, err)
+	}
+}
+
 func TestGetCredentialsForUser(t *testing.T) {
 	var mockCtrl = gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/pkg/management/endpoint.go
+++ b/pkg/management/endpoint.go
@@ -33,6 +33,7 @@ type Endpoints struct {
 	SendVerifyEmail                endpoint.Endpoint
 	ExecuteActionsEmail            endpoint.Endpoint
 	SendNewEnrolmentCode           endpoint.Endpoint
+	SendReminderEmail              endpoint.Endpoint
 	GetCredentialsForUser          endpoint.Endpoint
 	DeleteCredentialsForUser       endpoint.Endpoint
 	GetRoles                       endpoint.Endpoint
@@ -64,6 +65,7 @@ type ManagementComponent interface {
 	SendVerifyEmail(ctx context.Context, realmName string, userID string, paramKV ...string) error
 	ExecuteActionsEmail(ctx context.Context, realmName string, userID string, actions []api.RequiredAction, paramKV ...string) error
 	SendNewEnrolmentCode(ctx context.Context, realmName string, userID string) (string, error)
+	SendReminderEmail(ctx context.Context, realmName string, userID string, paramKV ...string) error
 	GetCredentialsForUser(ctx context.Context, realmName string, userID string) ([]api.CredentialRepresentation, error)
 	DeleteCredentialsForUser(ctx context.Context, realmName string, userID string, credentialID string) error
 	GetRoles(ctx context.Context, realmName string) ([]api.RoleRepresentation, error)
@@ -336,6 +338,22 @@ func MakeSendNewEnrolmentCodeEndpoint(managementComponent ManagementComponent) c
 
 		code, err := managementComponent.SendNewEnrolmentCode(ctx, m["realm"], m["userID"])
 		return map[string]string{"code": code}, err
+	}
+}
+
+// MakeSendReminderEmailEndpoint creates an endpoint for SendReminderEmail
+func MakeSendReminderEmailEndpoint(managementComponent ManagementComponent) cs.Endpoint {
+	return func(ctx context.Context, req interface{}) (interface{}, error) {
+		var m = req.(map[string]string)
+
+		var paramKV []string
+		for _, key := range []string{"client_id", "redirect_uri", "lifespan"} {
+			if m[key] != "" {
+				paramKV = append(paramKV, key, m[key])
+			}
+		}
+
+		return nil, managementComponent.SendReminderEmail(ctx, m["realm"], m["userID"], paramKV...)
 	}
 }
 

--- a/pkg/management/endpoint_test.go
+++ b/pkg/management/endpoint_test.go
@@ -599,6 +599,50 @@ func TestSendNewEnrolmentCodeEndpoint(t *testing.T) {
 
 }
 
+func TestSendReminderEmailEndpoint(t *testing.T) {
+	var mockCtrl = gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	var mockManagementComponent = mock.NewManagementComponent(mockCtrl)
+
+	var e = MakeSendReminderEmailEndpoint(mockManagementComponent)
+
+	// No error - Without param
+	{
+		var realm = "master"
+		var userID = "123-456-789"
+		var ctx = context.Background()
+		var req = make(map[string]string)
+		req["realm"] = realm
+		req["userID"] = userID
+
+		mockManagementComponent.EXPECT().SendReminderEmail(ctx, realm, userID).Return(nil).Times(1)
+		var res, err = e(ctx, req)
+		assert.Nil(t, err)
+		assert.Nil(t, res)
+	}
+
+	// No error - With params
+	{
+		var realm = "master"
+		var userID = "123-456-789"
+		var ctx = context.Background()
+		var req = make(map[string]string)
+		var lifespan = 3600
+		req["realm"] = realm
+		req["userID"] = userID
+		req["client_id"] = "123789"
+		req["redirect_uri"] = "http://redirect.com"
+		req["lifespan"] = string(lifespan)
+		req["toto"] = "tutu" // Check this param is not transmitted
+
+		mockManagementComponent.EXPECT().SendReminderEmail(ctx, realm, userID, "client_id", req["client_id"], "redirect_uri", req["redirect_uri"], "lifespan", req["lifespan"]).Return(nil).Times(1)
+		var res, err = e(ctx, req)
+		assert.Nil(t, err)
+		assert.Nil(t, res)
+	}
+}
+
 func TestGetCredentialsForUserEndpoint(t *testing.T) {
 	var mockCtrl = gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/pkg/management/endpoint_test.go
+++ b/pkg/management/endpoint_test.go
@@ -508,6 +508,7 @@ func TestSendVerifyEmailEndpoint(t *testing.T) {
 		var res, err = e(ctx, req)
 		assert.Nil(t, err)
 		assert.Nil(t, res)
+
 	}
 }
 
@@ -640,6 +641,7 @@ func TestSendReminderEmailEndpoint(t *testing.T) {
 		var res, err = e(ctx, req)
 		assert.Nil(t, err)
 		assert.Nil(t, res)
+		// the mock does not except to be called with req["toto"]; as the test passes it means that e has filtered out req["tutu"] and it is not transmitted to SendReminderEmail
 	}
 }
 


### PR DESCRIPTION
Add the new "send onboarding reminder mail" API in the bridge.
At the authorization level: SendReminderEmail is similar to SendVerifyEmail; to be decided if this will stay like this 