### PR TITLE
[CLOUDTRUST-1442] Empty set users

### DIFF
--- a/api/management/api.go
+++ b/api/management/api.go
@@ -29,7 +29,7 @@ type UserRepresentation struct {
 
 // UsersPageRepresentation used to manage paging in GetUsers
 type UsersPageRepresentation struct {
-	Users []UserRepresentation `json:"users,omitempty"`
+	Users []UserRepresentation `json:"users"`
 	Count *int                 `json:"count,omitempty"`
 }
 
@@ -155,7 +155,7 @@ func ConvertToAPIUser(userKc kc.UserRepresentation) UserRepresentation {
 
 // ConvertToAPIUsersPage converts paged users results from KC model to API one
 func ConvertToAPIUsersPage(users kc.UsersPageRepresentation) UsersPageRepresentation {
-	var slice []UserRepresentation
+	var slice []UserRepresentation = make([]UserRepresentation, 0)
 	for _, u := range users.Users {
 		slice = append(slice, ConvertToAPIUser(u))
 	}

--- a/api/management/api_test.go
+++ b/api/management/api_test.go
@@ -78,6 +78,13 @@ func TestConvertToAPIUsersPage(t *testing.T) {
 	assert.Equal(t, len(input.Users), len(output.Users))
 }
 
+func TestConvertToAPIUsersPageEmptySet(t *testing.T) {
+	var input = kc.UsersPageRepresentation{Count: nil, Users: nil}
+	var output = ConvertToAPIUsersPage(input)
+	assert.NotNil(t, output.Users)
+	assert.Equal(t, 0, len(output.Users))
+}
+
 func TestConvertToKCUser(t *testing.T) {
 	var user UserRepresentation
 


### PR DESCRIPTION
Bridge doesn't return the "users" empty array when there are no users