### PR TITLE
[CLOUDTRUST-1504] reset password

### DIFF
--- a/api/management/swagger-api_management.yaml
+++ b/api/management/swagger-api_management.yaml
@@ -395,7 +395,8 @@ paths:
     put:
       tags:
       - Users
-      summary: Set up a new password for the user.
+      summary: Set up a new password for the user. The value of the password is optional. 
+      If no password is provided, a password is generated and returned in the response.
       parameters:
       - name: realm
         in: path
@@ -414,9 +415,14 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Password'
+            allowEmptyValue: true
       responses:
         200:
           description: successful operation
+          content:
+              schema:
+                type: string
+              description: The newly generated password, if no value was provided.
   /realms/{realm}/users/{userID}/send-verify-email:
     put:
       tags:

--- a/api/management/swagger-api_management.yaml
+++ b/api/management/swagger-api_management.yaml
@@ -419,10 +419,11 @@ paths:
       responses:
         200:
           description: successful operation
-          content:
-              schema:
-                type: string
-              description: The newly generated password, if no value was provided.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Password'
+            description: The newly generated password, if no value was provided.
   /realms/{realm}/users/{userID}/send-verify-email:
     put:
       tags:

--- a/configs/authorization.json
+++ b/configs/authorization.json
@@ -953,6 +953,11 @@
           "end_user": {}
         }
       },
+      "ResetPassword": {
+        "DEP": {
+          "end_user": {}
+        }
+      },
       "GetGroups": {
         "DEP": {
           "*": {}

--- a/internal/keycloakb/passwordgeneration.go
+++ b/internal/keycloakb/passwordgeneration.go
@@ -1,7 +1,6 @@
 package keycloakb
 
 import (
-	"fmt"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -48,7 +47,6 @@ func GeneratePasswordFromKeycloakPolicy(policy string, minLength int) (string, e
 				for j := 0; j < minLength; j++ {
 					// make sure that the password has the minimum length required by choosing random lower case letters
 					pwdElems = append(pwdElems, string(lowerCase[rand.Intn(len(lowerCase))]))
-					fmt.Println(pwdElems)
 				}
 			} else {
 				return "", err
@@ -62,38 +60,32 @@ func GeneratePasswordFromKeycloakPolicy(policy string, minLength int) (string, e
 		switch keyValueItem[0] {
 		case "specialChars":
 			// pick randomly special characters from ?!#%$
-			fmt.Println("specialChars")
 			minRequired, err := strconv.Atoi(keyValueItem[1])
 			if err == nil {
 				specialChars := []string{"?", "!", "#", "%", "$"}
 				for j := 0; j < minRequired; j++ {
 					pwdElems = append(pwdElems, specialChars[rand.Intn(len(specialChars))])
-					fmt.Println(pwdElems)
 				}
 			} else {
 				return "", err
 			}
 
 		case "upperCase":
-			fmt.Println("upperCase")
 			minRequired, err := strconv.Atoi(keyValueItem[1])
 			if err == nil {
 				const upperCase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 				for j := 0; j < minRequired; j++ {
 					pwdElems = append(pwdElems, string(upperCase[rand.Intn(len(upperCase))]))
-					fmt.Println(pwdElems)
 				}
 			} else {
 				return "", err
 			}
 
 		case "digits":
-			fmt.Println("digits")
 			minRequired, err := strconv.Atoi(keyValueItem[1])
 			if err == nil {
 				for j := 0; j < minRequired; j++ {
 					pwdElems = append(pwdElems, strconv.Itoa(rand.Intn(10)))
-					fmt.Println(pwdElems)
 				}
 			} else {
 				return "", err
@@ -103,7 +95,6 @@ func GeneratePasswordFromKeycloakPolicy(policy string, minLength int) (string, e
 	}
 	rand.Shuffle(len(pwdElems), func(i, j int) { pwdElems[i], pwdElems[j] = pwdElems[j], pwdElems[i] })
 	pwd := strings.Join(pwdElems, "")
-	fmt.Println(pwd)
 	return pwd, nil
 
 }

--- a/internal/keycloakb/passwordgeneration.go
+++ b/internal/keycloakb/passwordgeneration.go
@@ -8,7 +8,11 @@ import (
 )
 
 const (
-	lowerCase = "abcdefghijklmnopqrstuvwxyz"
+	lowerCase    = "abcdefghijklmnopqrstuvwxyz"
+	upperCase    = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	specialChars = "?!#%$"
+	digits       = "0123456789"
+	alphabet     = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ?!*0123456789"
 )
 
 // appendCharacters appends a number of characters from a certain alphabet to a string array
@@ -42,9 +46,8 @@ func GeneratePassword(policy *string, minLength int, userID string) (string, err
 
 // GeneratePassword generates a password of a given length
 func GeneratePasswordNoKeycloakPolicy(minLength int) string {
-
 	var pwdElems []string
-	pwdElems = appendCharacters(pwdElems, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ?!*0123456789", minLength)
+	pwdElems = appendCharacters(pwdElems, alphabet, minLength)
 	pwd := strings.Join(pwdElems, "")
 	return pwd
 }
@@ -71,7 +74,7 @@ func GeneratePasswordFromKeycloakPolicy(policy string) (string, error) {
 			minRequired, err := strconv.Atoi(keyValueItem[1])
 			if err == nil {
 				// make sure that the password has the minimum length required by choosing random lower case letters
-				pwdElems = appendCharacters(pwdElems, "abcdefghijklmnopqrstuvwxyz", minRequired)
+				pwdElems = appendCharacters(pwdElems, lowerCase, minRequired)
 			} else {
 				return "", err
 			}
@@ -79,7 +82,7 @@ func GeneratePasswordFromKeycloakPolicy(policy string) (string, error) {
 			// pick randomly special characters from ?!#%$
 			minRequired, err := strconv.Atoi(keyValueItem[1])
 			if err == nil {
-				pwdElems = appendCharacters(pwdElems, "?!#%$", minRequired)
+				pwdElems = appendCharacters(pwdElems, specialChars, minRequired)
 			} else {
 				return "", err
 			}
@@ -87,7 +90,7 @@ func GeneratePasswordFromKeycloakPolicy(policy string) (string, error) {
 		case "upperCase":
 			minRequired, err := strconv.Atoi(keyValueItem[1])
 			if err == nil {
-				pwdElems = appendCharacters(pwdElems, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", minRequired)
+				pwdElems = appendCharacters(pwdElems, upperCase, minRequired)
 			} else {
 				return "", err
 			}
@@ -95,7 +98,7 @@ func GeneratePasswordFromKeycloakPolicy(policy string) (string, error) {
 		case "digits":
 			minRequired, err := strconv.Atoi(keyValueItem[1])
 			if err == nil {
-				pwdElems = appendCharacters(pwdElems, "0123456789", minRequired)
+				pwdElems = appendCharacters(pwdElems, digits, minRequired)
 			} else {
 				return "", err
 			}

--- a/internal/keycloakb/passwordgeneration.go
+++ b/internal/keycloakb/passwordgeneration.go
@@ -8,10 +8,10 @@ import (
 )
 
 const (
-	lowerCase    = "abcdefghijklmnopqrstuvwxyz"
-	upperCase    = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	lowerCase    = "abcdefghijkmnopqrstuvwxyz"
+	upperCase    = "ABCDEFGHJKLMNPQRSTUVWXYZ"
 	specialChars = "?!#%$"
-	digits       = "0123456789"
+	digits       = "23456789"
 	alphabet     = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ?!*0123456789"
 )
 

--- a/internal/keycloakb/passwordgeneration.go
+++ b/internal/keycloakb/passwordgeneration.go
@@ -4,29 +4,56 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
-	"time"
 	"unicode"
 )
 
-// GeneratePassword generates a password of a given length
-func GeneratePassword(minLength int) string {
+const (
+	lowerCase = "abcdefghijklmnopqrstuvwxyz"
+)
 
-	var pwdElems []string
-	const alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ?!*0123456789"
+// appendCharacters appends a number of characters from a certain alphabet to a string array
+func appendCharacters(pwdElems []string, alphabet string, length int) []string {
 
-	for j := 0; j < minLength; j++ {
+	for j := 0; j < length; j++ {
 		pwdElems = append(pwdElems, string(alphabet[rand.Intn(len(alphabet))]))
 	}
+	return pwdElems
+}
 
+// GeneratePassword generates a password accoring to the policy or minimum length imposed
+func GeneratePassword(policy *string, minLength int, userID string) (string, error) {
+	var pwd string
+	var err error
+
+	// generate a pwd != userID
+	for {
+		if policy != nil {
+			pwd, err = GeneratePasswordFromKeycloakPolicy(*policy)
+		} else {
+			pwd = GeneratePasswordNoKeycloakPolicy(minLength)
+		}
+		if pwd != userID {
+			break
+		}
+	}
+
+	return pwd, err
+}
+
+// GeneratePassword generates a password of a given length
+func GeneratePasswordNoKeycloakPolicy(minLength int) string {
+
+	var pwdElems []string
+	pwdElems = appendCharacters(pwdElems, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ?!*0123456789", minLength)
 	pwd := strings.Join(pwdElems, "")
 	return pwd
 }
 
 // GeneratePasswordFromKeycloakPolicy generates a random password respecting the keycloak password policy
-func GeneratePasswordFromKeycloakPolicy(policy string, minLength int) (string, error) {
+func GeneratePasswordFromKeycloakPolicy(policy string) (string, error) {
 	// Keycloak password policy is a string of the form
 	// "forceExpiredPasswordChange(365) and specialChars(1) and upperCase(1) and lowerCase(1) and length(4) and digits(1) and notUsername(undefined)"
-	var pwdElems []string
+	var pwdElems = make([]string, 0)
 	policyItems := strings.Split(policy, "and")
 
 	// generate a random password that corresponds to the password policy
@@ -40,32 +67,19 @@ func GeneratePasswordFromKeycloakPolicy(policy string, minLength int) (string, e
 	for i := 0; i < len(policyItems); i++ {
 		keyValueItem := strings.FieldsFunc(policyItems[i], f)
 		switch keyValueItem[0] {
-		case "length": // the minimum length of the password
-			minLength, err := strconv.Atoi(keyValueItem[1])
+		case "length", "lowerCase":
+			minRequired, err := strconv.Atoi(keyValueItem[1])
 			if err == nil {
-				const lowerCase = "abcdefghijklmnopqrstuvwxyz"
-				for j := 0; j < minLength; j++ {
-					// make sure that the password has the minimum length required by choosing random lower case letters
-					pwdElems = append(pwdElems, string(lowerCase[rand.Intn(len(lowerCase))]))
-				}
+				// make sure that the password has the minimum length required by choosing random lower case letters
+				pwdElems = appendCharacters(pwdElems, "abcdefghijklmnopqrstuvwxyz", minRequired)
 			} else {
 				return "", err
 			}
-		}
-	}
-
-	rand.Seed(time.Now().Unix())
-	for i := 0; i < len(policyItems); i++ {
-		keyValueItem := strings.FieldsFunc(policyItems[i], f)
-		switch keyValueItem[0] {
 		case "specialChars":
 			// pick randomly special characters from ?!#%$
 			minRequired, err := strconv.Atoi(keyValueItem[1])
 			if err == nil {
-				specialChars := []string{"?", "!", "#", "%", "$"}
-				for j := 0; j < minRequired; j++ {
-					pwdElems = append(pwdElems, specialChars[rand.Intn(len(specialChars))])
-				}
+				pwdElems = appendCharacters(pwdElems, "?!#%$", minRequired)
 			} else {
 				return "", err
 			}
@@ -73,10 +87,7 @@ func GeneratePasswordFromKeycloakPolicy(policy string, minLength int) (string, e
 		case "upperCase":
 			minRequired, err := strconv.Atoi(keyValueItem[1])
 			if err == nil {
-				const upperCase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-				for j := 0; j < minRequired; j++ {
-					pwdElems = append(pwdElems, string(upperCase[rand.Intn(len(upperCase))]))
-				}
+				pwdElems = appendCharacters(pwdElems, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", minRequired)
 			} else {
 				return "", err
 			}
@@ -84,9 +95,7 @@ func GeneratePasswordFromKeycloakPolicy(policy string, minLength int) (string, e
 		case "digits":
 			minRequired, err := strconv.Atoi(keyValueItem[1])
 			if err == nil {
-				for j := 0; j < minRequired; j++ {
-					pwdElems = append(pwdElems, strconv.Itoa(rand.Intn(10)))
-				}
+				pwdElems = appendCharacters(pwdElems, "0123456789", minRequired)
 			} else {
 				return "", err
 			}

--- a/internal/keycloakb/passwordgeneration.go
+++ b/internal/keycloakb/passwordgeneration.go
@@ -12,7 +12,7 @@ const (
 	upperCase    = "ABCDEFGHJKLMNPQRSTUVWXYZ"
 	specialChars = "?!#%$"
 	digits       = "23456789"
-	alphabet     = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ?!*0123456789"
+	alphabet     = "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ?!*23456789"
 )
 
 // appendCharacters appends a number of characters from a certain alphabet to a string array

--- a/internal/keycloakb/passwordgeneration.go
+++ b/internal/keycloakb/passwordgeneration.go
@@ -86,7 +86,6 @@ func GeneratePasswordFromKeycloakPolicy(policy string) (string, error) {
 			} else {
 				return "", err
 			}
-
 		case "upperCase":
 			minRequired, err := strconv.Atoi(keyValueItem[1])
 			if err == nil {
@@ -94,7 +93,6 @@ func GeneratePasswordFromKeycloakPolicy(policy string) (string, error) {
 			} else {
 				return "", err
 			}
-
 		case "digits":
 			minRequired, err := strconv.Atoi(keyValueItem[1])
 			if err == nil {

--- a/internal/keycloakb/passwordgeneration.go
+++ b/internal/keycloakb/passwordgeneration.go
@@ -101,7 +101,6 @@ func GeneratePasswordFromKeycloakPolicy(policy string) (string, error) {
 				return "", err
 			}
 		}
-
 	}
 	rand.Shuffle(len(pwdElems), func(i, j int) { pwdElems[i], pwdElems[j] = pwdElems[j], pwdElems[i] })
 	pwd := strings.Join(pwdElems, "")

--- a/internal/keycloakb/passwordgeneration.go
+++ b/internal/keycloakb/passwordgeneration.go
@@ -1,0 +1,109 @@
+package keycloakb
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+)
+
+// GeneratePassword generates a password of a given length
+func GeneratePassword(minLength int) string {
+
+	var pwdElems []string
+	const alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ?!*0123456789"
+
+	for j := 0; j < minLength; j++ {
+		pwdElems = append(pwdElems, string(alphabet[rand.Intn(len(alphabet))]))
+	}
+
+	pwd := strings.Join(pwdElems, "")
+	return pwd
+}
+
+// GeneratePasswordFromKeycloakPolicy generates a random password respecting the keycloak password policy
+func GeneratePasswordFromKeycloakPolicy(policy string, minLength int) (string, error) {
+	// Keycloak password policy is a string of the form
+	// "forceExpiredPasswordChange(365) and specialChars(1) and upperCase(1) and lowerCase(1) and length(4) and digits(1) and notUsername(undefined)"
+	var pwdElems []string
+	policyItems := strings.Split(policy, "and")
+
+	// generate a random password that corresponds to the password policy
+	//reg := regexp.MustCompile(`[a-zA-z]+[(]{1}[0-9]+[)]{1}`)
+	//pwdReq := string(reg.Find([]byte()))
+
+	f := func(c rune) bool {
+		return !unicode.IsLetter(c) && !unicode.IsNumber(c)
+	}
+
+	for i := 0; i < len(policyItems); i++ {
+		keyValueItem := strings.FieldsFunc(policyItems[i], f)
+		switch keyValueItem[0] {
+		case "length": // the minimum length of the password
+			minLength, err := strconv.Atoi(keyValueItem[1])
+			if err == nil {
+				const lowerCase = "abcdefghijklmnopqrstuvwxyz"
+				for j := 0; j < minLength; j++ {
+					// make sure that the password has the minimum length required by choosing random lower case letters
+					pwdElems = append(pwdElems, string(lowerCase[rand.Intn(len(lowerCase))]))
+					fmt.Println(pwdElems)
+				}
+			} else {
+				return "", err
+			}
+		}
+	}
+
+	rand.Seed(time.Now().Unix())
+	for i := 0; i < len(policyItems); i++ {
+		keyValueItem := strings.FieldsFunc(policyItems[i], f)
+		switch keyValueItem[0] {
+		case "specialChars":
+			// pick randomly special characters from ?!#%$
+			fmt.Println("specialChars")
+			minRequired, err := strconv.Atoi(keyValueItem[1])
+			if err == nil {
+				specialChars := []string{"?", "!", "#", "%", "$"}
+				for j := 0; j < minRequired; j++ {
+					pwdElems = append(pwdElems, specialChars[rand.Intn(len(specialChars))])
+					fmt.Println(pwdElems)
+				}
+			} else {
+				return "", err
+			}
+
+		case "upperCase":
+			fmt.Println("upperCase")
+			minRequired, err := strconv.Atoi(keyValueItem[1])
+			if err == nil {
+				const upperCase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+				for j := 0; j < minRequired; j++ {
+					pwdElems = append(pwdElems, string(upperCase[rand.Intn(len(upperCase))]))
+					fmt.Println(pwdElems)
+				}
+			} else {
+				return "", err
+			}
+
+		case "digits":
+			fmt.Println("digits")
+			minRequired, err := strconv.Atoi(keyValueItem[1])
+			if err == nil {
+				for j := 0; j < minRequired; j++ {
+					pwdElems = append(pwdElems, strconv.Itoa(rand.Intn(10)))
+					fmt.Println(pwdElems)
+				}
+			} else {
+				return "", err
+			}
+		}
+
+	}
+	rand.Shuffle(len(pwdElems), func(i, j int) { pwdElems[i], pwdElems[j] = pwdElems[j], pwdElems[i] })
+	pwd := strings.Join(pwdElems, "")
+	fmt.Println(pwd)
+	return pwd, nil
+
+}

--- a/internal/keycloakb/passwordgeneration_test.go
+++ b/internal/keycloakb/passwordgeneration_test.go
@@ -1,0 +1,86 @@
+package keycloakb
+
+import (
+	"fmt"
+	"math/rand"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppendCharacters(t *testing.T) {
+
+	rand.Seed(time.Now().Unix())
+	var pwdElems []string
+	var length int = rand.Intn(20)
+
+	pwdElems = appendCharacters(pwdElems, lowerCase, length)
+	assert.Equal(t, len(pwdElems), length)
+	for i := 0; i < len(pwdElems); i++ {
+		assert.Contains(t, lowerCase, pwdElems[i])
+	}
+
+	// empty password
+	length = 0
+	var emptypwdElem []string
+	emptypwdElem = appendCharacters(emptypwdElem, lowerCase, length)
+	assert.Empty(t, emptypwdElem)
+
+}
+
+func TestGeneratePasswordNoKeycloakPolicy(t *testing.T) {
+
+	rand.Seed(time.Now().Unix())
+	var length int = rand.Intn(20)
+
+	pwd := GeneratePasswordNoKeycloakPolicy(length)
+	assert.Equal(t, len(pwd), length)
+
+	for i := 0; i < len(pwd); i++ {
+		assert.Contains(t, alphabet, string(pwd[i]))
+	}
+}
+
+func TestGeneratePasswordFromKeycloakPolicy(t *testing.T) {
+	var nospecialChars = 3
+	var noupperCase = 2
+	var nolowerCase = 3
+	var length = 10
+	var nodigits = 1
+	var policy = fmt.Sprintf("forceExpiredPasswordChange(365) and specialChars(%d) and upperCase(%d) and lowerCase(%d) and length(%d) and digits(%d) and notUsername(undefined)", nospecialChars, noupperCase, nolowerCase, length, nodigits)
+
+	regSpecialChars := regexp.MustCompile("[?!#%$]")
+	regDigits := regexp.MustCompile("[0-9]")
+	regUpperCase := regexp.MustCompile("[A-Z]")
+	regLowerCase := regexp.MustCompile("[a-z]")
+
+	pwd, err := GeneratePasswordFromKeycloakPolicy(policy)
+	assert.Equal(t, len(regDigits.FindAllStringIndex(pwd, -1)), nodigits)
+	assert.Equal(t, len(regLowerCase.FindAllStringIndex(pwd, -1)), nolowerCase+length)
+	assert.Equal(t, len(regUpperCase.FindAllStringIndex(pwd, -1)), noupperCase)
+	assert.Equal(t, len(regSpecialChars.FindAllStringIndex(pwd, -1)), nospecialChars)
+	assert.True(t, len(pwd) >= length)
+	assert.Equal(t, len(pwd), nodigits+nolowerCase+nospecialChars+noupperCase+length)
+	assert.Nil(t, err)
+}
+
+func TestGeneratePassword(t *testing.T) {
+	var userID = "dummyID"
+	var minLength = 3
+	var nospecialChars = 3
+	var noupperCase = 2
+	var nolowerCase = 3
+	var length = 10
+	var nodigits = 1
+	var policy = fmt.Sprintf("forceExpiredPasswordChange(365) and specialChars(%d) and upperCase(%d) and lowerCase(%d) and length(%d) and digits(%d) and notUsername(undefined)", nospecialChars, noupperCase, nolowerCase, length, nodigits)
+
+	pwd, err := GeneratePassword(&policy, minLength, userID)
+	assert.Nil(t, err)
+	assert.Equal(t, len(pwd), nodigits+nolowerCase+nospecialChars+noupperCase+length)
+
+	pwd, err = GeneratePassword(nil, minLength, userID)
+	assert.Nil(t, err)
+	assert.Equal(t, len(pwd), minLength)
+}

--- a/pkg/management/authorization.go
+++ b/pkg/management/authorization.go
@@ -217,12 +217,12 @@ func (c *authorizationComponentMW) AddClientRolesToUser(ctx context.Context, rea
 	return c.next.AddClientRolesToUser(ctx, realmName, userID, clientID, roles)
 }
 
-func (c *authorizationComponentMW) ResetPassword(ctx context.Context, realmName string, userID string, password api.PasswordRepresentation) error {
+func (c *authorizationComponentMW) ResetPassword(ctx context.Context, realmName string, userID string, password api.PasswordRepresentation) (string, error) {
 	var action = ResetPassword
 	var targetRealm = realmName
 
 	if err := c.authManager.CheckAuthorizationOnTargetUser(ctx, action, targetRealm, userID); err != nil {
-		return err
+		return "", err
 	}
 
 	return c.next.ResetPassword(ctx, realmName, userID, password)

--- a/pkg/management/authorization_test.go
+++ b/pkg/management/authorization_test.go
@@ -121,7 +121,7 @@ func TestDeny(t *testing.T) {
 		err = authorizationMW.AddClientRolesToUser(ctx, realmName, userID, clientID, roles)
 		assert.Equal(t, security.ForbiddenError{}, err)
 
-		err = authorizationMW.ResetPassword(ctx, realmName, userID, password)
+		_, err = authorizationMW.ResetPassword(ctx, realmName, userID, password)
 		assert.Equal(t, security.ForbiddenError{}, err)
 
 		err = authorizationMW.SendVerifyEmail(ctx, realmName, userID)
@@ -317,8 +317,8 @@ func TestAllowed(t *testing.T) {
 		err = authorizationMW.AddClientRolesToUser(ctx, realmName, userID, clientID, roles)
 		assert.Nil(t, err)
 
-		mockManagementComponent.EXPECT().ResetPassword(ctx, realmName, userID, password).Return(nil).Times(1)
-		err = authorizationMW.ResetPassword(ctx, realmName, userID, password)
+		mockManagementComponent.EXPECT().ResetPassword(ctx, realmName, userID, password).Return("", nil).Times(1)
+		_, err = authorizationMW.ResetPassword(ctx, realmName, userID, password)
 		assert.Nil(t, err)
 
 		mockManagementComponent.EXPECT().SendVerifyEmail(ctx, realmName, userID).Return(nil).Times(1)

--- a/pkg/management/component.go
+++ b/pkg/management/component.go
@@ -3,13 +3,8 @@ package management
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"math/rand"
 	"regexp"
-	"strconv"
 	"strings"
-	"time"
-	"unicode"
 
 	cs "github.com/cloudtrust/common-service"
 	"github.com/cloudtrust/common-service/database"
@@ -496,9 +491,8 @@ func (c *component) AddClientRolesToUser(ctx context.Context, realmName, userID,
 func (c *component) ResetPassword(ctx context.Context, realmName string, userID string, password api.PasswordRepresentation) (string, error) {
 	var accessToken = ctx.Value(cs.CtContextAccessToken).(string)
 
-	fmt.Println("Reset password")
-
 	var pwd string
+	var err error
 	var credKc kc.CredentialRepresentation
 	var passwordType = "password"
 	credKc.Type = &passwordType
@@ -509,27 +503,26 @@ func (c *component) ResetPassword(ctx context.Context, realmName string, userID 
 
 		//obtain password policy
 		realmKc, _ := c.keycloakClient.GetRealm(accessToken, realmName)
-		fmt.Println("******************************")
 		if realmKc.PasswordPolicy == nil {
 			// no Keycloak password policy impose
-			pwd = generatePassword(minLength)
+			pwd = internal.GeneratePassword(minLength)
 		} else {
 			policy := *realmKc.PasswordPolicy
-			fmt.Println(policy)
-			pwd = generatePasswordFromKeycloakPolicy(policy, minLength)
+			pwd, err = internal.GeneratePasswordFromKeycloakPolicy(policy, minLength)
 			for pwd == userID {
 				// with small probability the generated password is the same as the username
-				pwd = generatePasswordFromKeycloakPolicy(policy, minLength)
+				pwd, err = internal.GeneratePasswordFromKeycloakPolicy(policy, minLength)
+			}
+			if err != nil {
+				return pwd, err
 			}
 		}
 		credKc.Value = &pwd
-		fmt.Println(pwd)
 	} else {
 		credKc.Value = password.Value
 	}
 
-	err := c.keycloakClient.ResetPassword(accessToken, realmName, userID, credKc)
-
+	err = c.keycloakClient.ResetPassword(accessToken, realmName, userID, credKc)
 	if err != nil {
 		c.logger.Warn("err", err.Error())
 		return pwd, err
@@ -539,81 +532,6 @@ func (c *component) ResetPassword(ctx context.Context, realmName string, userID 
 	_ = c.reportEvent(ctx, "INIT_PASSWORD", database.CtEventRealmName, realmName, database.CtEventUserID, userID)
 
 	return pwd, nil
-}
-
-func generatePassword(minLength int) string {
-	// generate a random password
-	fmt.Println("no keycloak policy")
-	var pwdElems []string
-	const alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ?!0123456789"
-	for j := 0; j < minLength; j++ {
-		pwdElems = append(pwdElems, string(alphabet[rand.Intn(len(alphabet))]))
-	}
-	fmt.Println(pwdElems)
-	pwd := strings.Join(pwdElems, "")
-	return pwd
-}
-
-func generatePasswordFromKeycloakPolicy(policy string, minLength int) string {
-	// Keycloak password policy is a string of the form
-	// "forceExpiredPasswordChange(365) and specialChars(1) and upperCase(1) and lowerCase(1) and length(4) and digits(1) and notUsername(undefined)"
-	var pwdElems []string
-	policyItems := strings.Split(policy, "and")
-	fmt.Println(policyItems)
-
-	// generate a random password that corresponds to the password policy
-	//reg := regexp.MustCompile(`[a-zA-z]+[(]{1}[0-9]+[)]{1}`)
-	//pwdReq := string(reg.Find([]byte()))
-
-	f := func(c rune) bool {
-		return !unicode.IsLetter(c) && !unicode.IsNumber(c)
-	}
-
-	// the minimum length of the password
-	for i := 0; i < len(policyItems); i++ {
-		keyValueItem := strings.FieldsFunc(policyItems[i], f)
-		switch keyValueItem[0] {
-		case "length":
-			minLength, _ = strconv.Atoi(keyValueItem[1]) // need to use must compile
-		}
-	}
-
-	rand.Seed(time.Now().Unix())
-	for i := 0; i < len(policyItems); i++ {
-		keyValueItem := strings.FieldsFunc(policyItems[i], f)
-		minRequired, _ := strconv.Atoi(keyValueItem[1])
-		switch keyValueItem[0] {
-		case "specialChars":
-			// piclk randomly special characters from ?!#%$
-			specialChars := []string{"?", "!", "#", "%", "$"}
-			for j := 0; j < minRequired; j++ {
-				pwdElems = append(pwdElems, specialChars[rand.Intn(len(specialChars))])
-			}
-			fmt.Println(pwdElems)
-		case "upperCase":
-			const upperCase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-			for j := 0; j < minRequired; j++ {
-				pwdElems = append(pwdElems, string(upperCase[rand.Intn(len(upperCase))]))
-			}
-			fmt.Println(pwdElems)
-		case "lowerCase":
-			const lowerCase = "abcdefghijklmnopqrstuvwxyz"
-			for j := 0; j < minLength; j++ { // make sure that the password has the minimum length required
-				pwdElems = append(pwdElems, string(lowerCase[rand.Intn(len(lowerCase))]))
-			}
-			fmt.Println(pwdElems)
-		case "digits":
-			for j := 0; j < minRequired; j++ {
-				pwdElems = append(pwdElems, strconv.Itoa(rand.Intn(10)))
-			}
-			fmt.Println(pwdElems)
-		}
-	}
-	rand.Shuffle(len(pwdElems), func(i, j int) { pwdElems[i], pwdElems[j] = pwdElems[j], pwdElems[i] })
-	fmt.Println(pwdElems)
-	pwd := strings.Join(pwdElems, "")
-	return pwd
-
 }
 
 func (c *component) SendVerifyEmail(ctx context.Context, realmName string, userID string, paramKV ...string) error {

--- a/pkg/management/endpoint.go
+++ b/pkg/management/endpoint.go
@@ -61,7 +61,7 @@ type ManagementComponent interface {
 	GetGroupsOfUser(ctx context.Context, realmName, userID string) ([]api.GroupRepresentation, error)
 	GetClientRolesForUser(ctx context.Context, realmName, userID, clientID string) ([]api.RoleRepresentation, error)
 	AddClientRolesToUser(ctx context.Context, realmName, userID, clientID string, roles []api.RoleRepresentation) error
-	ResetPassword(ctx context.Context, realmName string, userID string, password api.PasswordRepresentation) error
+	ResetPassword(ctx context.Context, realmName string, userID string, password api.PasswordRepresentation) (string, error)
 	SendVerifyEmail(ctx context.Context, realmName string, userID string, paramKV ...string) error
 	ExecuteActionsEmail(ctx context.Context, realmName string, userID string, actions []api.RequiredAction, paramKV ...string) error
 	SendNewEnrolmentCode(ctx context.Context, realmName string, userID string) (string, error)
@@ -281,7 +281,11 @@ func MakeResetPasswordEndpoint(managementComponent ManagementComponent) cs.Endpo
 			return nil, http.CreateBadRequestError(err.Error())
 		}
 
-		return nil, managementComponent.ResetPassword(ctx, m["realm"], m["userID"], password)
+		pwd, err := managementComponent.ResetPassword(ctx, m["realm"], m["userID"], password)
+		if pwd != "" {
+			return pwd, err
+		}
+		return nil, err
 	}
 }
 

--- a/pkg/management/endpoint_test.go
+++ b/pkg/management/endpoint_test.go
@@ -447,7 +447,7 @@ func TestResetPasswordEndpoint(t *testing.T) {
 		passwordJSON, _ := json.Marshal(api.PasswordRepresentation{})
 		req["body"] = string(passwordJSON)
 
-		mockManagementComponent.EXPECT().ResetPassword(ctx, realm, userID, api.PasswordRepresentation{}).Return(nil).Times(1)
+		mockManagementComponent.EXPECT().ResetPassword(ctx, realm, userID, api.PasswordRepresentation{}).Return("", nil).Times(1)
 		var res, err = e(ctx, req)
 		assert.Nil(t, err)
 		assert.Nil(t, res)

--- a/pkg/management/http_test.go
+++ b/pkg/management/http_test.go
@@ -98,7 +98,7 @@ func TestHTTPManagementHandler(t *testing.T) {
 		}
 		passwordJSON, _ := json.Marshal(passwordRep)
 
-		mockComponent.EXPECT().ResetPassword(gomock.Any(), "master", "f467ed7c-0a1d-4eee-9bb8-669c6f89c0ee", gomock.Any()).Return(nil).Times(1)
+		mockComponent.EXPECT().ResetPassword(gomock.Any(), "master", "f467ed7c-0a1d-4eee-9bb8-669c6f89c0ee", gomock.Any()).Return("", nil).Times(1)
 
 		var body = strings.NewReader(string(passwordJSON))
 		res, err := http.Post(ts.URL+"/realms/master/users/f467ed7c-0a1d-4eee-9bb8-669c6f89c0ee/reset-password", "application/json", body)


### PR DESCRIPTION
 adapt the exisiting reset-password endpoint to generate a random password if no value is provided in the request.
The generated value will be returned in the content of the response (JSON structure).
The randomly generated password must comply with the password policy defined in the target realm.