### PR TITLE
[CLOUDTRUST-1713] record 2ND_FACTOR_REMOVED event

### DIFF
--- a/pkg/management/component.go
+++ b/pkg/management/component.go
@@ -689,12 +689,12 @@ func (c *component) DeleteCredentialsForUser(ctx context.Context, realmName stri
 	var accessToken = ctx.Value(cs.CtContextAccessToken).(string)
 
 	// get the list of credentails of the user
-	credsKc, err := c.keycloakClient.GetCredentialsForUser(accessToken, ctxRealm, realmName, userID)
+	credsKc, err := c.keycloakClient.GetCredentials(accessToken, realmName, userID)
 	if err != nil {
 		c.logger.Warn("msg", "Could not obtain list of credentials", "err", err.Error())
 	}
 
-	err = c.keycloakClient.DeleteCredentialsForUser(accessToken, ctxRealm, realmName, userID, credentialID)
+	err = c.keycloakClient.DeleteCredential(accessToken, realmName, userID, credentialID)
 
 	if err != nil {
 		c.logger.Warn("err", err.Error())

--- a/pkg/management/component.go
+++ b/pkg/management/component.go
@@ -689,10 +689,36 @@ func (c *component) DeleteCredentialsForUser(ctx context.Context, realmName stri
 	var accessToken = ctx.Value(cs.CtContextAccessToken).(string)
 	var ctxRealm = ctx.Value(cs.CtContextRealm).(string)
 
-	err := c.keycloakClient.DeleteCredentialsForUser(accessToken, ctxRealm, realmName, userID, credentialID)
+	// get the list of credentails of the user
+	credsKc, err := c.keycloakClient.GetCredentialsForUser(accessToken, ctxRealm, realmName, userID)
+	if err != nil {
+		c.logger.Warn("msg", "Could not obtain list of credentials", "err", err.Error())
+	}
+
+	err = c.keycloakClient.DeleteCredentialsForUser(accessToken, ctxRealm, realmName, userID, credentialID)
 
 	if err != nil {
 		c.logger.Warn("err", err.Error())
+		return err
+	}
+
+	// if a credential other than the password was deleted, record the event 2ND_FACTOR_REMOVED in the audit DB
+	for _, credKc := range credsKc {
+		if *credKc.Id == credentialID && *credKc.Type != "password" {
+
+			errEvent := c.reportEvent(ctx, "2ND_FACTOR_REMOVED", database.CtEventRealmName, realmName, database.CtEventUserID, userID)
+			if errEvent != nil {
+				//store in the logs also the event that failed to be stored in the DB
+				m := map[string]interface{}{"event_name": "2ND_FACTOR_REMOVED", database.CtEventRealmName: realmName, database.CtEventUserID: userID}
+				eventJSON, errMarshal := json.Marshal(m)
+				if errMarshal == nil {
+					c.logger.Error("err", errEvent.Error(), "event", string(eventJSON))
+				} else {
+					c.logger.Error("err", errEvent.Error())
+				}
+			}
+			break
+		}
 	}
 
 	return err

--- a/pkg/management/component_test.go
+++ b/pkg/management/component_test.go
@@ -1673,8 +1673,8 @@ func TestDeleteCredentialsForUser(t *testing.T) {
 
 	// Delete credentials for user
 	{
-		mockKeycloakClient.EXPECT().GetCredentialsForUser(accessToken, realmReq, realmName, userID).Return([]kc.CredentialRepresentation{}, nil).Times(1)
-		mockKeycloakClient.EXPECT().DeleteCredentialsForUser(accessToken, realmReq, realmName, userID, credential).Return(nil).Times(1)
+		mockKeycloakClient.EXPECT().GetCredentials(accessToken, realmName, userID).Return([]kc.CredentialRepresentation{}, nil).Times(1)
+		mockKeycloakClient.EXPECT().DeleteCredential(accessToken, realmName, userID, credential).Return(nil).Times(1)
 
 		var ctx = context.WithValue(context.Background(), cs.CtContextAccessToken, accessToken)
 		ctx = context.WithValue(ctx, cs.CtContextRealm, realmReq)
@@ -1685,9 +1685,9 @@ func TestDeleteCredentialsForUser(t *testing.T) {
 	}
 	// Delete credentials for user - error at obtaining the list of credentials
 	{
-		mockKeycloakClient.EXPECT().GetCredentialsForUser(accessToken, realmReq, realmName, userID).Return([]kc.CredentialRepresentation{}, errors.New("error")).Times(1)
+		mockKeycloakClient.EXPECT().GetCredentials(accessToken, realmName, userID).Return([]kc.CredentialRepresentation{}, errors.New("error")).Times(1)
 		mockLogger.EXPECT().Warn("msg", "Could not obtain list of credentials", "err", "error")
-		mockKeycloakClient.EXPECT().DeleteCredentialsForUser(accessToken, realmReq, realmName, userID, credential).Return(nil).Times(1)
+		mockKeycloakClient.EXPECT().DeleteCredential(accessToken, realmName, userID, credential).Return(nil).Times(1)
 
 		var ctx = context.WithValue(context.Background(), cs.CtContextAccessToken, accessToken)
 		ctx = context.WithValue(ctx, cs.CtContextRealm, realmReq)
@@ -1699,8 +1699,8 @@ func TestDeleteCredentialsForUser(t *testing.T) {
 	}
 	// Delete credentials for user - error at deleting the credential
 	{
-		mockKeycloakClient.EXPECT().GetCredentialsForUser(accessToken, realmReq, realmName, userID).Return([]kc.CredentialRepresentation{}, nil).Times(1)
-		mockKeycloakClient.EXPECT().DeleteCredentialsForUser(accessToken, realmReq, realmName, userID, credential).Return(errors.New("error")).Times(1)
+		mockKeycloakClient.EXPECT().GetCredentials(accessToken, realmName, userID).Return([]kc.CredentialRepresentation{}, nil).Times(1)
+		mockKeycloakClient.EXPECT().DeleteCredential(accessToken, realmName, userID, credential).Return(errors.New("error")).Times(1)
 		mockLogger.EXPECT().Warn("err", "error")
 		var ctx = context.WithValue(context.Background(), cs.CtContextAccessToken, accessToken)
 		ctx = context.WithValue(ctx, cs.CtContextRealm, realmReq)
@@ -1734,8 +1734,8 @@ func TestDeleteCredentialsForUser(t *testing.T) {
 		var ctx = context.WithValue(context.Background(), cs.CtContextAccessToken, accessToken)
 		ctx = context.WithValue(ctx, cs.CtContextRealm, realmReq)
 
-		mockKeycloakClient.EXPECT().GetCredentialsForUser(accessToken, realmReq, realmName, userID).Return(credsKc, nil).Times(1)
-		mockKeycloakClient.EXPECT().DeleteCredentialsForUser(accessToken, realmReq, realmName, userID, otpId).Return(nil).Times(1)
+		mockKeycloakClient.EXPECT().GetCredentials(accessToken, realmName, userID).Return(credsKc, nil).Times(1)
+		mockKeycloakClient.EXPECT().DeleteCredential(accessToken, realmName, userID, otpId).Return(nil).Times(1)
 		mockEventDBModule.EXPECT().ReportEvent(ctx, "2ND_FACTOR_REMOVED", "back-office", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 		err := managementComponent.DeleteCredentialsForUser(ctx, realmName, userID, otpId)
@@ -1766,8 +1766,8 @@ func TestDeleteCredentialsForUser(t *testing.T) {
 		var ctx = context.WithValue(context.Background(), cs.CtContextAccessToken, accessToken)
 		ctx = context.WithValue(ctx, cs.CtContextRealm, realmReq)
 
-		mockKeycloakClient.EXPECT().GetCredentialsForUser(accessToken, realmReq, realmName, userID).Return(credsKc, nil).Times(1)
-		mockKeycloakClient.EXPECT().DeleteCredentialsForUser(accessToken, realmReq, realmName, userID, otpId).Return(nil).Times(1)
+		mockKeycloakClient.EXPECT().GetCredentials(accessToken, realmName, userID).Return(credsKc, nil).Times(1)
+		mockKeycloakClient.EXPECT().DeleteCredential(accessToken, realmName, userID, otpId).Return(nil).Times(1)
 		mockEventDBModule.EXPECT().ReportEvent(ctx, "2ND_FACTOR_REMOVED", "back-office", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("error")).Times(1)
 		m := map[string]interface{}{"event_name": "2ND_FACTOR_REMOVED", database.CtEventRealmName: realmName, database.CtEventUserID: userID}
 		eventJSON, _ := json.Marshal(m)

--- a/pkg/management/component_test.go
+++ b/pkg/management/component_test.go
@@ -1662,7 +1662,7 @@ func TestDeleteCredentialsForUser(t *testing.T) {
 	var mockKeycloakClient = mock.NewKeycloakClient(mockCtrl)
 	var mockEventDBModule = mock.NewEventDBModule(mockCtrl)
 	var mockConfigurationDBModule = mock.NewConfigurationDBModule(mockCtrl)
-	var mockLogger = log.NewNopLogger()
+	var mockLogger = mock.NewLogger(mockCtrl)
 
 	var managementComponent = NewComponent(mockKeycloakClient, mockEventDBModule, mockConfigurationDBModule, mockLogger)
 	var accessToken = "TOKEN=="
@@ -1671,8 +1671,9 @@ func TestDeleteCredentialsForUser(t *testing.T) {
 	var userID = "1245-7854-8963"
 	var credential = "987-654-321"
 
-	// Get credentials for user
+	// Delete credentials for user
 	{
+		mockKeycloakClient.EXPECT().GetCredentialsForUser(accessToken, realmReq, realmName, userID).Return([]kc.CredentialRepresentation{}, nil).Times(1)
 		mockKeycloakClient.EXPECT().DeleteCredentialsForUser(accessToken, realmReq, realmName, userID, credential).Return(nil).Times(1)
 
 		var ctx = context.WithValue(context.Background(), cs.CtContextAccessToken, accessToken)
@@ -1682,6 +1683,100 @@ func TestDeleteCredentialsForUser(t *testing.T) {
 
 		assert.Nil(t, err)
 	}
+	// Delete credentials for user - error at obtaining the list of credentials
+	{
+		mockKeycloakClient.EXPECT().GetCredentialsForUser(accessToken, realmReq, realmName, userID).Return([]kc.CredentialRepresentation{}, errors.New("error")).Times(1)
+		mockLogger.EXPECT().Warn("msg", "Could not obtain list of credentials", "err", "error")
+		mockKeycloakClient.EXPECT().DeleteCredentialsForUser(accessToken, realmReq, realmName, userID, credential).Return(nil).Times(1)
+
+		var ctx = context.WithValue(context.Background(), cs.CtContextAccessToken, accessToken)
+		ctx = context.WithValue(ctx, cs.CtContextRealm, realmReq)
+
+		err := managementComponent.DeleteCredentialsForUser(ctx, realmName, userID, credential)
+
+		assert.Nil(t, err)
+
+	}
+	// Delete credentials for user - error at deleting the credential
+	{
+		mockKeycloakClient.EXPECT().GetCredentialsForUser(accessToken, realmReq, realmName, userID).Return([]kc.CredentialRepresentation{}, nil).Times(1)
+		mockKeycloakClient.EXPECT().DeleteCredentialsForUser(accessToken, realmReq, realmName, userID, credential).Return(errors.New("error")).Times(1)
+		mockLogger.EXPECT().Warn("err", "error")
+		var ctx = context.WithValue(context.Background(), cs.CtContextAccessToken, accessToken)
+		ctx = context.WithValue(ctx, cs.CtContextRealm, realmReq)
+
+		err := managementComponent.DeleteCredentialsForUser(ctx, realmName, userID, credential)
+
+		assert.NotNil(t, err)
+
+	}
+	// Delete credentials for user
+	{
+
+		pwdId := "51389847-08f4-4a0f-9f9c-694554e626f2"
+		pwd := "password"
+		var credKcPwd = kc.CredentialRepresentation{
+			Id:   &pwdId,
+			Type: &pwd,
+		}
+
+		otpId := "51389847-08f4-4a0f-9f9c-694554e626f3"
+		totp := "totp"
+		var credKcOtp = kc.CredentialRepresentation{
+			Id:   &otpId,
+			Type: &totp,
+		}
+
+		var credsKc []kc.CredentialRepresentation
+		credsKc = append(credsKc, credKcPwd)
+		credsKc = append(credsKc, credKcOtp)
+
+		var ctx = context.WithValue(context.Background(), cs.CtContextAccessToken, accessToken)
+		ctx = context.WithValue(ctx, cs.CtContextRealm, realmReq)
+
+		mockKeycloakClient.EXPECT().GetCredentialsForUser(accessToken, realmReq, realmName, userID).Return(credsKc, nil).Times(1)
+		mockKeycloakClient.EXPECT().DeleteCredentialsForUser(accessToken, realmReq, realmName, userID, otpId).Return(nil).Times(1)
+		mockEventDBModule.EXPECT().ReportEvent(ctx, "2ND_FACTOR_REMOVED", "back-office", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+		err := managementComponent.DeleteCredentialsForUser(ctx, realmName, userID, otpId)
+
+		assert.Nil(t, err)
+	}
+	// Delete credentials for user - error at storing the event
+	{
+
+		pwdId := "51389847-08f4-4a0f-9f9c-694554e626f2"
+		pwd := "password"
+		var credKcPwd = kc.CredentialRepresentation{
+			Id:   &pwdId,
+			Type: &pwd,
+		}
+
+		otpId := "51389847-08f4-4a0f-9f9c-694554e626f3"
+		totp := "totp"
+		var credKcOtp = kc.CredentialRepresentation{
+			Id:   &otpId,
+			Type: &totp,
+		}
+
+		var credsKc []kc.CredentialRepresentation
+		credsKc = append(credsKc, credKcPwd)
+		credsKc = append(credsKc, credKcOtp)
+
+		var ctx = context.WithValue(context.Background(), cs.CtContextAccessToken, accessToken)
+		ctx = context.WithValue(ctx, cs.CtContextRealm, realmReq)
+
+		mockKeycloakClient.EXPECT().GetCredentialsForUser(accessToken, realmReq, realmName, userID).Return(credsKc, nil).Times(1)
+		mockKeycloakClient.EXPECT().DeleteCredentialsForUser(accessToken, realmReq, realmName, userID, otpId).Return(nil).Times(1)
+		mockEventDBModule.EXPECT().ReportEvent(ctx, "2ND_FACTOR_REMOVED", "back-office", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("error")).Times(1)
+		m := map[string]interface{}{"event_name": "2ND_FACTOR_REMOVED", database.CtEventRealmName: realmName, database.CtEventUserID: userID}
+		eventJSON, _ := json.Marshal(m)
+		mockLogger.EXPECT().Error("err", "error", "event", string(eventJSON))
+		err := managementComponent.DeleteCredentialsForUser(ctx, realmName, userID, otpId)
+
+		assert.Nil(t, err)
+	}
+
 }
 
 func TestGetRoles(t *testing.T) {


### PR DESCRIPTION
if a credential other than the password was deleted, record the event 2ND_FACTOR_REMOVED in the audit DB