### PR TITLE
Cloudtrust 1771 fix timezone

### DIFF
--- a/configs/keycloak_bridge.yml
+++ b/configs/keycloak_bridge.yml
@@ -48,7 +48,7 @@ db-audit-rw-username: root
 db-audit-rw-password: admin
 db-audit-rw-database: auditevents
 db-audit-rw-protocol: tcp
-db-audit-rw-parameters: time_zone='UTC'
+db-audit-rw-parameters: 
 db-audit-rw-max-open-conns: 10
 db-audit-rw-max-idle-conns: 2
 db-audit-rw-conn-max-lifetime: 10
@@ -63,7 +63,7 @@ db-audit-ro-username: root
 db-audit-ro-password: admin
 db-audit-ro-database: auditevents
 db-audit-ro-protocol: tcp
-db-audit-ro-parameters: time_zone='UTC'
+db-audit-ro-parameters: 
 db-audit-ro-max-open-conns: 10
 db-audit-ro-max-idle-conns: 2
 db-audit-ro-conn-max-lifetime: 10
@@ -77,7 +77,7 @@ db-config-username: bridge
 db-config-password: bridge-password 
 db-config-database: cloudtrust_configuration
 db-config-protocol: tcp
-db-config-parameters: time_zone='UTC'
+db-config-parameters: 
 db-config-max-open-conns: 10
 db-config-max-idle-conns: 2
 db-config-conn-max-lifetime: 10

--- a/pkg/event/component.go
+++ b/pkg/event/component.go
@@ -199,7 +199,8 @@ func adminEventToMap(adminEvent *fb.AdminEvent) map[string]string {
 
 	addInfo["uid"] = fmt.Sprint(adminEvent.Uid())
 
-	time := epochMilliToTime(adminEvent.Time()).UTC()
+	//TZ set to Locale to avoid to have to add UTC into connection string to DB
+	time := epochMilliToTime(adminEvent.Time()).Local()
 	adminEventMap[database.CtEventAuditTime] = time.Format(timeFormat) //audit_time
 
 	adminEventMap[database.CtEventRealmName] = string(adminEvent.RealmId()) //realm_name


### PR DESCRIPTION
Due to an issue with MariaDB reported by SSO, usage of time_zone=UTC in DB connection string leads to some issues in their side. 
We change to use system locale and we now need to assume Locale of Db and Bridge are aligned.