### PR TITLE
[CLOUDTRUST-1875] Return error with message when Realm config is not configured

### DIFF
--- a/cmd/keycloakb/keycloak_bridge.go
+++ b/cmd/keycloakb/keycloak_bridge.go
@@ -670,13 +670,13 @@ func main() {
 		var getAccountHandler = configureAccountHandler(keycloakb.ComponentName, ComponentID, idGenerator, keycloakClient, audienceRequired, tracer, logger)(accountEndpoints.GetAccount)
 		var updateAccountHandler = configureAccountHandler(keycloakb.ComponentName, ComponentID, idGenerator, keycloakClient, audienceRequired, tracer, logger)(accountEndpoints.UpdateAccount)
 		var deleteAccountHandler = configureAccountHandler(keycloakb.ComponentName, ComponentID, idGenerator, keycloakClient, audienceRequired, tracer, logger)(accountEndpoints.DeleteAccount)
-		var getGetConfiguration = configureAccountHandler(keycloakb.ComponentName, ComponentID, idGenerator, keycloakClient, audienceRequired, tracer, logger)(accountEndpoints.GetConfiguration)
+		var getConfigurationHandler = configureAccountHandler(keycloakb.ComponentName, ComponentID, idGenerator, keycloakClient, audienceRequired, tracer, logger)(accountEndpoints.GetConfiguration)
 
 		route.Path("/account").Methods("GET").Handler(getAccountHandler)
 		route.Path("/account").Methods("POST").Handler(updateAccountHandler)
 		route.Path("/account").Methods("DELETE").Handler(deleteAccountHandler)
 
-		route.Path("/account/configuration").Methods("GET").Handler(getGetConfiguration)
+		route.Path("/account/configuration").Methods("GET").Handler(getConfigurationHandler)
 
 		route.Path("/account/credentials").Methods("GET").Handler(getCredentialsHandler)
 		route.Path("/account/credentials/password").Methods("POST").Handler(updatePasswordHandler)

--- a/internal/keycloakb/errormessages.go
+++ b/internal/keycloakb/errormessages.go
@@ -13,7 +13,9 @@ const (
 	MsgErrCannotSaveConfigInDB = "cannotSaveConfigInDB"
 	MsgErrCannotUpdate         = "cannotUpdate"
 	MsgErrUnknown              = "unknowError"
+	MsgErrNotConfigured        = "notConfigured"
 
+	RealmConfiguration = "realmConfiguration"
 	CurrentPassword    = "currentPassword"
 	NewPassword        = "newPassword"
 	ConfirmPassword    = "confirmPassword"

--- a/pkg/account/component.go
+++ b/pkg/account/component.go
@@ -3,7 +3,6 @@ package account
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"strconv"
 
@@ -321,7 +320,6 @@ func (c *component) GetConfiguration(ctx context.Context) (api.Configuration, er
 
 	config, err := c.configDBModule.GetConfiguration(ctx, currentRealm)
 	if err != nil {
-		fmt.Println("isssue")
 		return api.Configuration{}, err
 	}
 

--- a/pkg/account/component.go
+++ b/pkg/account/component.go
@@ -3,6 +3,7 @@ package account
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -320,6 +321,7 @@ func (c *component) GetConfiguration(ctx context.Context) (api.Configuration, er
 
 	config, err := c.configDBModule.GetConfiguration(ctx, currentRealm)
 	if err != nil {
+		fmt.Println("isssue")
 		return api.Configuration{}, err
 	}
 

--- a/pkg/management/component.go
+++ b/pkg/management/component.go
@@ -864,7 +864,7 @@ func (c *component) GetRealmCustomConfiguration(ctx context.Context, realmName s
 	// DB error
 	if err != nil {
 		switch e := errors.Cause(err).(type) {
-		case internal.MissingRealmConfigurationErr:
+		case errorhandler.Error:
 			c.logger.Warn("message", e.Error())
 			return api.RealmCustomConfiguration{
 				DefaultClientID:                     new(string),

--- a/pkg/management/component_test.go
+++ b/pkg/management/component_test.go
@@ -12,10 +12,10 @@ import (
 	cs "github.com/cloudtrust/common-service"
 	"github.com/cloudtrust/common-service/database"
 	commonhttp "github.com/cloudtrust/common-service/errors"
+	errorhandler "github.com/cloudtrust/common-service/errors"
 	"github.com/cloudtrust/common-service/log"
 	api "github.com/cloudtrust/keycloak-bridge/api/management"
 	"github.com/cloudtrust/keycloak-bridge/internal/dto"
-	"github.com/cloudtrust/keycloak-bridge/internal/keycloakb"
 	"github.com/cloudtrust/keycloak-bridge/pkg/management/mock"
 	kc "github.com/cloudtrust/keycloak-client"
 	"github.com/golang/mock/gomock"
@@ -2165,7 +2165,7 @@ func TestGetRealmCustomConfiguration(t *testing.T) {
 		mockKeycloakClient.EXPECT().GetRealm(accessToken, realmID).Return(kcRealmRep, nil).Times(1)
 
 		var ctx = context.WithValue(context.Background(), cs.CtContextAccessToken, accessToken)
-		mockConfigurationDBModule.EXPECT().GetConfiguration(ctx, realmID).Return(dto.RealmConfiguration{}, keycloakb.MissingRealmConfigurationErr{}).Times(1)
+		mockConfigurationDBModule.EXPECT().GetConfiguration(ctx, realmID).Return(dto.RealmConfiguration{}, errorhandler.Error{}).Times(1)
 
 		configJSON, err := managementComponent.GetRealmCustomConfiguration(ctx, realmID)
 


### PR DESCRIPTION
return a 404 with message when realmconfig is not configured; before it was a 500