### PR TITLE
[CLOUDTRUST-1898] Support making releases through https.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
               sh """
                 cd ${BUILD_PATH}/bin
                 tar -czvf ${APP}-${params.VERSION}.tar.gz ./keycloak_bridge
-                curl -u"${USR}:${PWD}" -T "${BUILD_PATH}/bin/${APP}-${params.VERSION}.tar.gz" --keepalive-time 2 "${REPO_URL}/${APP}-${params.VERSION}.tar.gz"
+                curl -k -u"${USR}:${PWD}" -T "${BUILD_PATH}/bin/${APP}-${params.VERSION}.tar.gz" --keepalive-time 2 "${REPO_URL}/${APP}-${params.VERSION}.tar.gz"
               """
             }
             def git_url = "${env.GIT_URL}".replaceFirst("^(http[s]?://www\\.|http[s]?://|www\\.)","")


### PR DESCRIPTION
With an old version of curl (7.29 in our case), and when pushing our release to a tls-enabled server, it happens that the certificate is treated to be invalid even if the hostname is explicitely written in the Subject Alternative Name as a DNS name.

The common fix is just to pass curl -k and bypass the certificate validation, sadly.