### PR TITLE
Fix deprecated nancy colouring option.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
             golint | tee golint.out || true
             gometalinter | tee gometalinter.out || true
 
-            nancy -noColor Gopkg.lock || true
+            nancy -no-color Gopkg.lock || true
 
             JAVA_TOOL_OPTIONS="" sonar-scanner \
               -Dsonar.host.url=http://sonarqube:9000 \


### PR DESCRIPTION
The -noColor option of nancy got deprecated in v0.0.29. Instead, it got replaced by -no-color.