### PR TITLE
[CLOUDTRUST-2264] Add GetUser (by id) in kyc API

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,16 +10,16 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:c659a6247d43eca4d74b53fade2e032a8882b055ba5aad02d154189b18ae3739"
+  digest = "1:875c90e39ff3e917c933c3f611bc61657bda8834e7fc59498f1a4ff0e23edefb"
   name = "github.com/certifi/gocertifi"
   packages = ["."]
   pruneopts = "UT"
-  revision = "a6d78f326758ac5f79e9c3eddc38723d07216c3a"
-  version = "2020.01.04"
+  revision = "c7c1fbc02894e7114f06f6a4d9ab31eee2225bdb"
+  version = "2020.02.11"
 
 [[projects]]
-  branch = "validation"
-  digest = "1:bfdecb354f0efe307ee6de69fc1f57e368a499ea8319d29b9daaebdf644e3ffa"
+  branch = "master"
+  digest = "1:a04a4e86d8b1fbb095a569998ba5adec39501d7872d79075a4aabaa791ad465c"
   name = "github.com/cloudtrust/common-service"
   packages = [
     ".",
@@ -38,15 +38,15 @@
     "validation",
   ]
   pruneopts = "UT"
-  revision = "a2fd235de5d0bf062789a6f0b2f58c81dbf96338"
+  revision = "790d30f843ed1e0868693c39f2345a7840925075"
 
 [[projects]]
-  branch = "validation"
-  digest = "1:71cf3ff9622cbd9accbb19448f23c30cb1975474a3bee20efc229e521c62cf63"
+  branch = "dev"
+  digest = "1:140e5ecc3aa692117302296807e3ae5f6e53f587036af47330806bd42b6dde73"
   name = "github.com/cloudtrust/keycloak-client"
   packages = ["."]
   pruneopts = "UT"
-  revision = "b3a4178420b8953126b2eac53b242c73e430a16f"
+  revision = "aecba0a68c090df0174b1f53f33b5c9a43ea061c"
 
 [[projects]]
   digest = "1:910c5b111ca13127693df80a59be2c952ad97313626116c0c9895e7b588f2a29"
@@ -147,12 +147,12 @@
   version = "1.11.0"
 
 [[projects]]
-  digest = "1:cbec35fe4d5a4fba369a656a8cd65e244ea2c743007d8f6c1ccb132acf9d1296"
+  digest = "1:25ebe6496abb289ef977c081b2d49f56dd97c32db4ca083d37f95923909ced02"
   name = "github.com/gorilla/mux"
   packages = ["."]
   pruneopts = "UT"
-  revision = "00bdffe0f3c77e27d2cf6f5c70232a2d3e4d9c15"
-  version = "v1.7.3"
+  revision = "75dcda0896e109a2a22c9315bca3bb21b87b2ba5"
+  version = "v1.7.4"
 
 [[projects]]
   digest = "1:c0d19ab64b32ce9fe5cf4ddceba78d5bc9807f0016db6b1183599da3dcc24d10"
@@ -427,11 +427,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:72b7c210f8cfe1431d2f300fbf37f25e52aa77324b05ab6b698483054033803e"
+  digest = "1:21170ea1a15ba3b4e49dd934e130f4e21edf3c117e24f07502fe46e45ff3a8fc"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "d101bd2416d505c0448a6ce8a282482678040a89"
+  revision = "12a6c2dcc1e4cb348b57847c73987099e261714b"
 
 [[projects]]
   digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
@@ -477,7 +477,7 @@
     "go/types/typeutil",
   ]
   pruneopts = "UT"
-  revision = "2de505fc5306574bc26fdcf5aca1e37ed187421e"
+  revision = "49b8ac185c84c5092be0953fb92b7660db9b8162"
 
 [[projects]]
   digest = "1:e0a1881f9e0564bebdeac98c75e59f07acdde6ed3a5396e0e613eaad31194866"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,13 +27,11 @@
 
 [[constraint]]
   name = "github.com/cloudtrust/common-service"
-#  version = "v1.2.4"
-  branch = "validation"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/cloudtrust/keycloak-client"
-#  version = "v1.2.7"
-  branch = "validation"
+  branch = "dev"
 
 [[constraint]]
   name = "github.com/go-kit/kit"

--- a/api/kyc/swagger-api_kyc.yaml
+++ b/api/kyc/swagger-api_kyc.yaml
@@ -31,13 +31,19 @@ paths:
     get:
       tags:
       - KYC
-      summary: Gets a user
+      summary: Gets a user (search by username)
       security:
         - openId: []
       parameters:
       - name: username
         in: query
         description: name of the user to be retrieved
+        required: true
+        schema:
+          type: string
+      - name: groupIds
+        in: query
+        description: list of groupId the users may belong to (list comma seperated)
         required: true
         schema:
           type: string
@@ -50,9 +56,29 @@ paths:
                 $ref: '#/components/schemas/User'
         403:
           description: No permission to call this operation
-        404:
-          description: User not found
   /kyc/users/{userId}:
+    get:
+      tags:
+      - KYC
+      summary: Gets a user
+      security:
+        - openId: []
+      parameters:
+      - name: userId
+        in: path
+        description: user id
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        403:
+          description: No permission to call this operation
     put:
       tags:
       - KYC
@@ -75,7 +101,7 @@ paths:
               $ref: '#/components/schemas/User'
       responses:
         200:
-          description: Successful operation. Returns the generated username
+          description: Successful operation
           content:
             application/json:
               schema:
@@ -97,9 +123,12 @@ components:
       type: object
       required: [gender, firstName, lastName, emailAddress, phoneNumber]
       properties:
-        id:
+        userId:
           type: string
-          description: User ID is used by GET user, ignored by PUT user
+          description: Ignored by PUT user
+        username:
+          type: string
+          description: Ignored by PUT user
         gender:
           type: string
         firstName:
@@ -108,12 +137,16 @@ components:
           type: string
         emailAddress:
           type: string
+          description: Ignored by PUT user
         emailAddressVerified:
           type: boolean
+          description: Ignored by PUT user
         phoneNumber:
           type: string
+          description: Ignored by PUT user
         phoneNumberVerified:
           type: boolean
+          description: Ignored by PUT user
         birthDate:
           type: string
           description: format is DD.MM.YYYY

--- a/cmd/keycloakb/keycloak_bridge.go
+++ b/cmd/keycloakb/keycloak_bridge.go
@@ -660,9 +660,10 @@ func main() {
 		kycComponent = kyc.MakeAuthorizationRegisterComponentMW(registerRealm, log.With(kycLogger, "mw", "endpoint"), authorizationManager)(kycComponent)
 
 		kycEndpoints = kyc.Endpoints{
-			GetActions:   prepareEndpoint(kyc.MakeGetActionsEndpoint(kycComponent), "register_get_actions", influxMetrics, kycLogger, tracer, rateLimit["kyc"]),
-			GetUser:      prepareEndpoint(kyc.MakeGetUserEndpoint(kycComponent), "get_user", influxMetrics, kycLogger, tracer, rateLimit["kyc"]),
-			ValidateUser: prepareEndpoint(kyc.MakeValidateUserEndpoint(kycComponent), "validate_user", influxMetrics, kycLogger, tracer, rateLimit["kyc"]),
+			GetActions:        prepareEndpoint(kyc.MakeGetActionsEndpoint(kycComponent), "register_get_actions", influxMetrics, kycLogger, tracer, rateLimit["kyc"]),
+			GetUser:           prepareEndpoint(kyc.MakeGetUserEndpoint(kycComponent), "get_user", influxMetrics, kycLogger, tracer, rateLimit["kyc"]),
+			GetUserByUsername: prepareEndpoint(kyc.MakeGetUserByUsernameEndpoint(kycComponent), "get_user_by_username", influxMetrics, kycLogger, tracer, rateLimit["kyc"]),
+			ValidateUser:      prepareEndpoint(kyc.MakeValidateUserEndpoint(kycComponent), "validate_user", influxMetrics, kycLogger, tracer, rateLimit["kyc"]),
 		}
 	}
 
@@ -829,6 +830,7 @@ func main() {
 		// KYC handlers
 		var kycGetActionsHandler = configureKYCHandler(keycloakb.ComponentName, ComponentID, idGenerator, keycloakClient, audienceRequired, tracer, logger)(kycEndpoints.GetActions)
 		var kycGetUserHandler = configureKYCHandler(keycloakb.ComponentName, ComponentID, idGenerator, keycloakClient, audienceRequired, tracer, logger)(kycEndpoints.GetUser)
+		var kycGetUserByUsernameHandler = configureKYCHandler(keycloakb.ComponentName, ComponentID, idGenerator, keycloakClient, audienceRequired, tracer, logger)(kycEndpoints.GetUserByUsername)
 		var kycValidateUserHandler = configureKYCHandler(keycloakb.ComponentName, ComponentID, idGenerator, keycloakClient, audienceRequired, tracer, logger)(kycEndpoints.ValidateUser)
 
 		// actions
@@ -893,7 +895,8 @@ func main() {
 
 		// KYC methods
 		route.Path("/kyc/actions").Methods("GET").Handler(kycGetActionsHandler)
-		route.Path("/kyc/users").Methods("GET").Handler(kycGetUserHandler)
+		route.Path("/kyc/users").Methods("GET").Handler(kycGetUserByUsernameHandler)
+		route.Path("/kyc/users/{userId}").Methods("GET").Handler(kycGetUserHandler)
 		route.Path("/kyc/users/{userId}").Methods("PUT").Handler(kycValidateUserHandler)
 
 		var handler http.Handler = route

--- a/pkg/kyc/endpoint.go
+++ b/pkg/kyc/endpoint.go
@@ -2,6 +2,7 @@ package kyc
 
 import (
 	"context"
+	"strings"
 
 	cs "github.com/cloudtrust/common-service"
 	commonerrors "github.com/cloudtrust/common-service/errors"
@@ -12,9 +13,10 @@ import (
 
 // Endpoints for self service
 type Endpoints struct {
-	GetActions   endpoint.Endpoint
-	GetUser      endpoint.Endpoint
-	ValidateUser endpoint.Endpoint
+	GetActions        endpoint.Endpoint
+	GetUser           endpoint.Endpoint
+	GetUserByUsername endpoint.Endpoint
+	ValidateUser      endpoint.Endpoint
 }
 
 // MakeGetActionsEndpoint creates an endpoint for GetActions
@@ -24,11 +26,27 @@ func MakeGetActionsEndpoint(component Component) cs.Endpoint {
 	}
 }
 
+// MakeGetUserByUsernameEndpoint endpoint creation
+func MakeGetUserByUsernameEndpoint(component Component) cs.Endpoint {
+	return func(ctx context.Context, req interface{}) (interface{}, error) {
+		var m = req.(map[string]string)
+		var user = m["username"]
+
+		_, ok := m["groupIds"]
+		if !ok {
+			return nil, commonerrors.CreateMissingParameterError(msg.GroupIDs)
+		}
+		groupIDs := strings.Split(m["groupIds"], ",")
+
+		return component.GetUserByUsername(ctx, user, groupIDs)
+	}
+}
+
 // MakeGetUserEndpoint endpoint creation
 func MakeGetUserEndpoint(component Component) cs.Endpoint {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		var m = req.(map[string]string)
-		var user = m["username"]
+		var user = m["userId"]
 		return component.GetUser(ctx, user)
 	}
 }

--- a/pkg/kyc/endpoint_test.go
+++ b/pkg/kyc/endpoint_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	apikyc "github.com/cloudtrust/keycloak-bridge/api/kyc"
@@ -41,20 +42,52 @@ func TestMakeGetUserEndpoint(t *testing.T) {
 	mockKYCComponent := mock.NewComponent(mockCtrl)
 
 	var realm = "master"
-	var username = "user1234"
-	var m = map[string]string{"realm": realm, "username": username}
+	var userID = "user1234"
+	var m = map[string]string{"realm": realm, "userId": userID}
 	var expectedError = errors.New("get-user")
 
 	t.Run("GetUser - success case", func(t *testing.T) {
-		mockKYCComponent.EXPECT().GetUser(gomock.Any(), username).Return(apikyc.UserRepresentation{}, nil)
+		mockKYCComponent.EXPECT().GetUser(gomock.Any(), userID).Return(apikyc.UserRepresentation{}, nil)
 		_, err := MakeGetUserEndpoint(mockKYCComponent)(context.Background(), m)
 		assert.Nil(t, err)
 	})
 
 	t.Run("GetUser - failure case", func(t *testing.T) {
-		mockKYCComponent.EXPECT().GetUser(gomock.Any(), username).Return(apikyc.UserRepresentation{}, expectedError)
+		mockKYCComponent.EXPECT().GetUser(gomock.Any(), userID).Return(apikyc.UserRepresentation{}, expectedError)
 		_, err := MakeGetUserEndpoint(mockKYCComponent)(context.Background(), m)
 		assert.Equal(t, expectedError, err)
+	})
+}
+
+func TestMakeGetUserByUsernameEndpoint(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockKYCComponent := mock.NewComponent(mockCtrl)
+
+	var realm = "master"
+	var username = "user1234"
+	var groupIDList = "group1,group2,group3"
+	var groupIDs = strings.Split(groupIDList, ",")
+	var m = map[string]string{"realm": realm, "username": username, "groupIds": groupIDList}
+	var expectedError = errors.New("get-user")
+
+	t.Run("GetUserByUsername - success case", func(t *testing.T) {
+		mockKYCComponent.EXPECT().GetUserByUsername(gomock.Any(), username, groupIDs).Return(apikyc.UserRepresentation{}, nil)
+		_, err := MakeGetUserByUsernameEndpoint(mockKYCComponent)(context.Background(), m)
+		assert.Nil(t, err)
+	})
+
+	t.Run("GetUserByUsername - failure case", func(t *testing.T) {
+		mockKYCComponent.EXPECT().GetUserByUsername(gomock.Any(), username, groupIDs).Return(apikyc.UserRepresentation{}, expectedError)
+		_, err := MakeGetUserByUsernameEndpoint(mockKYCComponent)(context.Background(), m)
+		assert.Equal(t, expectedError, err)
+	})
+
+	t.Run("GetUserByUsername - missing groupIDs", func(t *testing.T) {
+		var missingGroupIDs = map[string]string{"realm": realm, "username": username}
+		_, err := MakeGetUserByUsernameEndpoint(mockKYCComponent)(context.Background(), missingGroupIDs)
+		assert.NotNil(t, err)
 	})
 }
 

--- a/pkg/kyc/http.go
+++ b/pkg/kyc/http.go
@@ -15,12 +15,16 @@ import (
 const (
 	RegExpUserName = apimgmt.RegExpUsername
 	RegExpUserID   = apimgmt.RegExpID
+	RegExpGroupIds = apimgmt.RegExpGroupIds
 )
 
 // MakeKYCHandler make an HTTP handler for the KYC endpoint.
 func MakeKYCHandler(e endpoint.Endpoint, logger log.Logger) *http_transport.Server {
 	pathParams := map[string]string{"userId": RegExpUserID}
-	queryParams := map[string]string{"username": RegExpUserName}
+	queryParams := map[string]string{
+		"username": RegExpUserName,
+		"groupIds": RegExpGroupIds,
+	}
 
 	return http_transport.NewServer(e,
 		func(ctx context.Context, req *http.Request) (interface{}, error) {


### PR DESCRIPTION
Coverage should decrease but I don't want to write unit tests for deprecated methods that will be removed soon.