### PR TITLE
[CLOUDTRUST-2297] Add flag for user accreditations

### DIFF
--- a/api/account/api_test.go
+++ b/api/account/api_test.go
@@ -44,6 +44,7 @@ func TestConvertToAPIAccount(t *testing.T) {
 		"birthDate":           []string{"15.02.1920"},
 		"locale":              []string{"fr"},
 		"phoneNumberVerified": []string{"true"},
+		"accreditations":      []string{`{"type":"one","expiryDate":"05.04.2020"}`, `{"type":"two","expiryDate":"05.03.2022"}`},
 	}
 
 	t.Run("Check attributes are copied", func(t *testing.T) {
@@ -54,6 +55,7 @@ func TestConvertToAPIAccount(t *testing.T) {
 		assert.Equal(t, "15.02.1920", *user.BirthDate)
 		assert.Equal(t, "fr", *user.Locale)
 		assert.True(t, *user.PhoneNumberVerified)
+		assert.Len(t, *user.Accreditations, 2)
 	})
 
 	t.Run("PhoneNumberVerified is invalid", func(t *testing.T) {

--- a/api/account/swagger-api_account.yaml
+++ b/api/account/swagger-api_account.yaml
@@ -244,6 +244,21 @@ components:
           description: only returned by /account
         locale:
           type: string
+        accreditations:
+          type: array
+          description: only returned by /account
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                description: accreditation type
+              expiryDate:
+                type: string
+                description: expiry date. format is DD.MM.YYYY
+              expired:
+                type: bool
+                description: true if the expiry date has passed
     Configuration:
       type: object
       properties:

--- a/api/kyc/swagger-api_kyc.yaml
+++ b/api/kyc/swagger-api_kyc.yaml
@@ -165,6 +165,21 @@ components:
         validation:
           type: string
           description: Only provided by getUser
+        accreditations:
+          type: array
+          description: Used only by getUser
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                description: accreditation type
+              expiryDate:
+                type: string
+                description: expiry date. format is DD.MM.YYYY
+              expired:
+                type: bool
+                description: true if the expiry date has passed
   securitySchemes:
     openId:
       type: openIdConnect

--- a/api/management/api_test.go
+++ b/api/management/api_test.go
@@ -34,54 +34,60 @@ func TestConvertToAPIUser(t *testing.T) {
 	var kcUser kc.UserRepresentation
 	m := make(kc.Attributes)
 
-	// Phone number
-	assert.Nil(t, ConvertToAPIUser(kcUser).PhoneNumber)
-	kcUser.Attributes = &m
-	m.SetString(constants.AttrbPhoneNumber, "+4122555555")
-	assert.NotNil(t, ConvertToAPIUser(kcUser).PhoneNumber)
-
-	// Label
-	assert.Nil(t, ConvertToAPIUser(kcUser).Label)
-	kcUser.Attributes = &m
-	m.SetString(constants.AttrbLabel, "a label")
-	assert.NotNil(t, ConvertToAPIUser(kcUser).Label)
-
-	// Gender
-	assert.Nil(t, ConvertToAPIUser(kcUser).Gender)
-	kcUser.Attributes = &m
-	m.SetString(constants.AttrbGender, "a gender")
-	assert.NotNil(t, ConvertToAPIUser(kcUser).Gender)
-
-	// Birthdate
-	assert.Nil(t, ConvertToAPIUser(kcUser).BirthDate)
-	kcUser.Attributes = &m
-	m.SetString(constants.AttrbBirthDate, "25/12/0")
-	assert.NotNil(t, ConvertToAPIUser(kcUser).BirthDate)
-
-	// PhoneNumberVerified
-	assert.Nil(t, ConvertToAPIUser(kcUser).PhoneNumberVerified)
-	kcUser.Attributes = &m
-	m.SetBool(constants.AttrbPhoneNumberVerified, true)
-	assert.True(t, *ConvertToAPIUser(kcUser).PhoneNumberVerified)
-
-	// Locale
-	assert.Nil(t, ConvertToAPIUser(kcUser).Locale)
-	kcUser.Attributes = &m
-	m.SetString(constants.AttrbLocale, "en")
-	assert.NotNil(t, *ConvertToAPIUser(kcUser).Locale)
-
-	// SmsSent
-	assert.Nil(t, ConvertToAPIUser(kcUser).SmsSent)
-	kcUser.Attributes = &m
-	m.SetInt(constants.AttrbSmsSent, 0)
-	m["smsSent"] = []string{"0"}
-	assert.NotNil(t, *ConvertToAPIUser(kcUser).SmsSent)
-
-	// trustID groups
-	assert.Nil(t, ConvertToAPIUser(kcUser).TrustIDGroups)
-	kcUser.Attributes = &m
-	m.SetString(constants.AttrbTrustIDGroups, "en")
-	assert.NotNil(t, *ConvertToAPIUser(kcUser).TrustIDGroups)
+	t.Run("Phone number", func(t *testing.T) {
+		assert.Nil(t, ConvertToAPIUser(kcUser).PhoneNumber)
+		kcUser.Attributes = &m
+		m.SetString(constants.AttrbPhoneNumber, "+4122555555")
+		assert.NotNil(t, ConvertToAPIUser(kcUser).PhoneNumber)
+	})
+	t.Run("Label", func(t *testing.T) {
+		assert.Nil(t, ConvertToAPIUser(kcUser).Label)
+		kcUser.Attributes = &m
+		m.SetString(constants.AttrbLabel, "a label")
+		assert.NotNil(t, ConvertToAPIUser(kcUser).Label)
+	})
+	t.Run("Gender", func(t *testing.T) {
+		assert.Nil(t, ConvertToAPIUser(kcUser).Gender)
+		kcUser.Attributes = &m
+		m.SetString(constants.AttrbGender, "a gender")
+		assert.NotNil(t, ConvertToAPIUser(kcUser).Gender)
+	})
+	t.Run("Birthdate", func(t *testing.T) {
+		assert.Nil(t, ConvertToAPIUser(kcUser).BirthDate)
+		kcUser.Attributes = &m
+		m.SetString(constants.AttrbBirthDate, "25/12/0")
+		assert.NotNil(t, ConvertToAPIUser(kcUser).BirthDate)
+	})
+	t.Run("Phone number verified", func(t *testing.T) {
+		assert.Nil(t, ConvertToAPIUser(kcUser).PhoneNumberVerified)
+		kcUser.Attributes = &m
+		m.SetBool(constants.AttrbPhoneNumberVerified, true)
+		assert.True(t, *ConvertToAPIUser(kcUser).PhoneNumberVerified)
+	})
+	t.Run("Locale", func(t *testing.T) {
+		assert.Nil(t, ConvertToAPIUser(kcUser).Locale)
+		kcUser.Attributes = &m
+		m.SetString(constants.AttrbLocale, "en")
+		assert.NotNil(t, *ConvertToAPIUser(kcUser).Locale)
+	})
+	t.Run("SMS sent", func(t *testing.T) {
+		assert.Nil(t, ConvertToAPIUser(kcUser).SmsSent)
+		kcUser.Attributes = &m
+		m.SetInt(constants.AttrbSmsSent, 0)
+		m["smsSent"] = []string{"0"}
+		assert.NotNil(t, *ConvertToAPIUser(kcUser).SmsSent)
+	})
+	t.Run("trustID groups", func(t *testing.T) {
+		assert.Nil(t, ConvertToAPIUser(kcUser).TrustIDGroups)
+		kcUser.Attributes = &m
+		m.SetString(constants.AttrbTrustIDGroups, "en")
+		assert.NotNil(t, *ConvertToAPIUser(kcUser).TrustIDGroups)
+	})
+	t.Run("Accreditations", func(t *testing.T) {
+		assert.Nil(t, ConvertToAPIUser(kcUser).Accreditations)
+		kcUser.SetAttribute("accreditations", []string{`{"type":"one","expiryDate":"05.04.2020"}`, `{"type":"two","expiryDate":"05.03.2022"}`})
+		assert.Len(t, *ConvertToAPIUser(kcUser).Accreditations, 2)
+	})
 }
 
 func TestConvertToAPIUsersPage(t *testing.T) {

--- a/api/management/swagger-api_management.yaml
+++ b/api/management/swagger-api_management.yaml
@@ -1200,6 +1200,21 @@ components:
         locale:
           type: string
           default: "en"
+        accreditations:
+          type: array
+          description: Used only by getUser
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                description: accreditation type
+              expiryDate:
+                type: string
+                description: expiry date. format is DD.MM.YYYY
+              expired:
+                type: bool
+                description: true if the expiry date has passed
     UserStatus:
       type: object
       properties:

--- a/api/validation/api.go
+++ b/api/validation/api.go
@@ -85,6 +85,10 @@ var (
 		"REVIEW_PENDING":            true,
 		"FRAUD_SUSPICION_PENDING":   true,
 	}
+	successStatus = map[string]bool{
+		"SUCCESS":              true,
+		"SUCCESS_DATA_CHANGED": true,
+	}
 )
 
 // ConvertToDBCheck creates a DBCheck
@@ -198,4 +202,9 @@ func (c *CheckRepresentation) Validate() error {
 		ValidateParameterRegExp(prmCheckNature, c.Nature, regExpNature, true).
 		ValidateParameterRegExp(prmCheckProofType, c.ProofType, regExpProofType, true).
 		Status()
+}
+
+// IsIdentificationSuccessful tells whether a check is success or not
+func (c *CheckRepresentation) IsIdentificationSuccessful() bool {
+	return c.Status != nil && successStatus[*c.Status]
 }

--- a/api/validation/api_test.go
+++ b/api/validation/api_test.go
@@ -219,3 +219,21 @@ func TestCheckValidate(t *testing.T) {
 		}
 	})
 }
+
+func TestIsIdentificationSuccessful(t *testing.T) {
+	var check CheckRepresentation
+	t.Run("Status is nil", func(t *testing.T) {
+		check.Status = nil
+		assert.False(t, check.IsIdentificationSuccessful())
+	})
+	t.Run("Status is not a known success value", func(t *testing.T) {
+		var unknown = "unknown"
+		check.Status = &unknown
+		assert.False(t, check.IsIdentificationSuccessful())
+	})
+	t.Run("Status is a success value", func(t *testing.T) {
+		var success = "SUCCESS"
+		check.Status = &success
+		assert.True(t, check.IsIdentificationSuccessful())
+	})
+}

--- a/internal/constants/keycloak.go
+++ b/internal/constants/keycloak.go
@@ -12,6 +12,7 @@ var (
 
 // Attribute keys definition
 const (
+	AttrbAccreditations      = kc.AttributeKey("accreditations")
 	AttrbBirthDate           = kc.AttributeKey("birthDate")
 	AttrbGender              = kc.AttributeKey("gender")
 	AttrbLabel               = kc.AttributeKey("label")

--- a/internal/keycloakb/accreditationsmodule.go
+++ b/internal/keycloakb/accreditationsmodule.go
@@ -1,0 +1,133 @@
+package keycloakb
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/cloudtrust/common-service/configuration"
+	errorhandler "github.com/cloudtrust/common-service/errors"
+	"github.com/cloudtrust/common-service/validation"
+	"github.com/cloudtrust/keycloak-bridge/internal/constants"
+	kc "github.com/cloudtrust/keycloak-client"
+)
+
+var (
+	dateLayout = constants.SupportedDateLayouts[0]
+)
+
+const (
+	// CredsIDNow identifies the condition for IDNow service
+	CredsIDNow = configuration.CheckKeyIDNow
+	// CredsPhysical identifies the condition for physical identification
+	CredsPhysical = configuration.CheckKeyPhysical
+)
+
+// AccreditationsModule interface
+type AccreditationsModule interface {
+	GetUserAndPrepareAccreditations(ctx context.Context, accessToken, realmName, userID, condition string) (kc.UserRepresentation, int, error)
+}
+
+// AccredsKeycloakClient is the minimum Keycloak client interface for accreditations
+type AccredsKeycloakClient interface {
+	UpdateUser(accessToken string, realmName, userID string, user kc.UserRepresentation) error
+	GetUser(accessToken string, realmName, userID string) (kc.UserRepresentation, error)
+	GetRealm(accessToken string, realmName string) (kc.RealmRepresentation, error)
+}
+
+// AdminConfigurationDBModule interface
+type AdminConfigurationDBModule interface {
+	GetAdminConfiguration(context.Context, string) (configuration.RealmAdminConfiguration, error)
+}
+
+type accredsModule struct {
+	keycloakClient AccredsKeycloakClient
+	confDBModule   AdminConfigurationDBModule
+	logger         Logger
+}
+
+// AccreditationRepresentation is a representation of accreditations
+type AccreditationRepresentation struct {
+	Type       *string `json:"type,omitempty"`
+	ExpiryDate *string `json:"expiryDate,omitempty"`
+}
+
+// NewAccreditationsModule creates an accreditations module
+func NewAccreditationsModule(keycloakClient AccredsKeycloakClient, confDBModule AdminConfigurationDBModule, logger Logger) AccreditationsModule {
+	return &accredsModule{
+		keycloakClient: keycloakClient,
+		confDBModule:   confDBModule,
+		logger:         logger,
+	}
+}
+
+func (am *accredsModule) GetUserAndPrepareAccreditations(ctx context.Context, accessToken, realmName, userID, condition string) (kc.UserRepresentation, int, error) {
+	var kcUser kc.UserRepresentation
+
+	// Gets the realm
+	var realm, err = am.keycloakClient.GetRealm(accessToken, realmName)
+	if err != nil {
+		am.logger.Warn(ctx, "msg", "getKeycloakRealm: can't get realm from KC", "err", err.Error())
+		return kcUser, 0, errorhandler.CreateInternalServerError("keycloak")
+	}
+
+	// Retrieve admin configuration from configuration DB
+	var rac configuration.RealmAdminConfiguration
+	rac, err = am.confDBModule.GetAdminConfiguration(ctx, *realm.Id)
+	if err != nil {
+		am.logger.Warn(ctx, "msg", "CreateAccreditations: can't get admin configuration", "err", err.Error())
+		return kcUser, 0, errorhandler.CreateInternalServerError("keycloak")
+	}
+
+	// Evaluate accreditations to be created
+	var newAccreds []string
+	for _, modelAccred := range rac.Accreditations {
+		if modelAccred.Condition == nil || *modelAccred.Condition == condition {
+			var expiry *string
+			expiry, err = am.convertDurationToDate(ctx, *modelAccred.Validity)
+			if err != nil {
+				return kcUser, 0, err
+			}
+			var newAccreditationJSON, _ = json.Marshal(AccreditationRepresentation{
+				Type:       modelAccred.Type,
+				ExpiryDate: expiry,
+			})
+			newAccreds = append(newAccreds, string(newAccreditationJSON))
+		}
+	}
+
+	// Get the user from Keycloak
+	kcUser, err = am.keycloakClient.GetUser(accessToken, realmName, userID)
+	if err != nil {
+		am.logger.Warn(ctx, "msg", "CreateAccreditations: can't get Keycloak user", "err", err.Error(), "realm", realmName, "user", userID)
+		return kcUser, 0, err
+	}
+
+	// Update attributes in kcUser
+	// If no new accreditation, return
+	var added = 0
+	if len(newAccreds) > 0 {
+		var kcAccreds = kcUser.GetAttribute(constants.AttrbAccreditations)
+		for _, newAccred := range newAccreds {
+			if !validation.IsStringInSlice(kcAccreds, newAccred) {
+				kcAccreds = append(kcAccreds, newAccred)
+				added++
+			}
+		}
+		kcUser.SetAttribute(constants.AttrbAccreditations, kcAccreds)
+	}
+
+	return kcUser, added, nil
+}
+
+func (am *accredsModule) convertDurationToDate(ctx context.Context, validity string) (*string, error) {
+	var expiryDate, err = validation.AddLargeDurationE(time.Now(), validity)
+	if err != nil {
+		am.logger.Warn(ctx, "msg", "convertDurationToDate: can't convert duration", "duration", validity, "err", err.Error())
+		return nil, errorhandler.CreateInternalServerError("duration-convertion")
+	}
+
+	var res = expiryDate.Format(dateLayout)
+
+	return &res, nil
+}

--- a/internal/keycloakb/accreditationsmodule_test.go
+++ b/internal/keycloakb/accreditationsmodule_test.go
@@ -1,0 +1,118 @@
+package keycloakb
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cloudtrust/keycloak-bridge/internal/constants"
+
+	"github.com/cloudtrust/common-service/configuration"
+	"github.com/cloudtrust/common-service/log"
+	"github.com/cloudtrust/common-service/validation"
+	"github.com/cloudtrust/keycloak-bridge/internal/keycloakb/mock"
+	kc "github.com/cloudtrust/keycloak-client"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func createRealmAdminCred(typeValue, validity, condition string) configuration.RealmAdminAccreditation {
+	return configuration.RealmAdminAccreditation{
+		Type:      &typeValue,
+		Validity:  &validity,
+		Condition: &condition,
+	}
+}
+
+const (
+	duration1 = "2y"
+	duration2 = "1w"
+	duration3 = "6m"
+)
+
+func createRealmAdminConfig(condition string) configuration.RealmAdminConfiguration {
+	var otherCondition = "no-" + condition
+	var accreds = []configuration.RealmAdminAccreditation{
+		createRealmAdminCred("SHADOW1", duration1, condition),
+		createRealmAdminCred("SHADOW2", "1y", otherCondition),
+		createRealmAdminCred("SHADOW3", duration2, condition),
+		createRealmAdminCred("SHADOW4", "3y", otherCondition),
+		createRealmAdminCred("SHADOW5", duration3, condition),
+	}
+	return configuration.RealmAdminConfiguration{Accreditations: accreds}
+}
+
+func TestAccreditationsModule(t *testing.T) {
+	var mockCtrl = gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	var mockKeycloak = mock.NewAccredsKeycloakClient(mockCtrl)
+	var mockConfDB = mock.NewConfigurationDBModule(mockCtrl)
+	var logger = log.NewNopLogger()
+
+	var accredsModule = NewAccreditationsModule(mockKeycloak, mockConfDB, logger)
+
+	var ctx = context.TODO()
+	var accessToken = "access-token"
+	var realmName = "realm-name"
+	var realmID = "the-realm-id"
+	var userID = "the-user-id"
+	var anyError = errors.New("I don't know")
+	var condition = "physical"
+	var otherCondition = "other"
+	var kcRealm = kc.RealmRepresentation{Id: &realmID}
+	var kcUser = kc.UserRepresentation{Id: &userID}
+
+	t.Run("Keycloak.GetRealm fails", func(t *testing.T) {
+		mockKeycloak.EXPECT().GetRealm(accessToken, realmName).Return(kc.RealmRepresentation{}, anyError)
+		var _, _, err = accredsModule.GetUserAndPrepareAccreditations(ctx, accessToken, realmName, userID, condition)
+		assert.NotNil(t, err)
+	})
+	t.Run("Database.GetAdminConfiguration fails", func(t *testing.T) {
+		mockKeycloak.EXPECT().GetRealm(accessToken, realmName).Return(kcRealm, nil)
+		mockConfDB.EXPECT().GetAdminConfiguration(ctx, realmID).Return(configuration.RealmAdminConfiguration{}, anyError)
+		var _, _, err = accredsModule.GetUserAndPrepareAccreditations(ctx, accessToken, realmName, userID, condition)
+		assert.NotNil(t, err)
+	})
+	t.Run("No condition matches", func(t *testing.T) {
+		mockKeycloak.EXPECT().GetRealm(accessToken, realmName).Return(kcRealm, nil)
+		mockConfDB.EXPECT().GetAdminConfiguration(ctx, realmID).Return(createRealmAdminConfig(otherCondition), nil)
+		mockKeycloak.EXPECT().GetUser(accessToken, realmName, userID).Return(kc.UserRepresentation{}, nil)
+		var _, _, err = accredsModule.GetUserAndPrepareAccreditations(ctx, accessToken, realmName, userID, condition)
+		assert.Nil(t, err)
+	})
+	t.Run("Invalid accreditation validity duration", func(t *testing.T) {
+		var credsConf = createRealmAdminConfig(condition)
+		var invalidDuration = "??"
+		credsConf.Accreditations[0].Validity = &invalidDuration
+		mockKeycloak.EXPECT().GetRealm(accessToken, realmName).Return(kcRealm, nil)
+		mockConfDB.EXPECT().GetAdminConfiguration(ctx, realmID).Return(credsConf, nil)
+		var _, _, err = accredsModule.GetUserAndPrepareAccreditations(ctx, accessToken, realmName, userID, condition)
+		assert.NotNil(t, err)
+	})
+	t.Run("Keycloak.GetUser fails", func(t *testing.T) {
+		mockKeycloak.EXPECT().GetRealm(accessToken, realmName).Return(kcRealm, nil)
+		mockConfDB.EXPECT().GetAdminConfiguration(ctx, realmID).Return(createRealmAdminConfig(condition), nil)
+		mockKeycloak.EXPECT().GetUser(accessToken, realmName, userID).Return(kc.UserRepresentation{}, anyError)
+		var _, _, err = accredsModule.GetUserAndPrepareAccreditations(ctx, accessToken, realmName, userID, condition)
+		assert.NotNil(t, err)
+	})
+	t.Run("Accreditations creation is successful", func(t *testing.T) {
+		kcUser.Attributes = nil
+		mockKeycloak.EXPECT().GetRealm(accessToken, realmName).Return(kcRealm, nil)
+		mockConfDB.EXPECT().GetAdminConfiguration(ctx, realmID).Return(createRealmAdminConfig(condition), nil)
+		mockKeycloak.EXPECT().GetUser(accessToken, realmName, userID).Return(kcUser, nil)
+		var kcUser, count, err = accredsModule.GetUserAndPrepareAccreditations(ctx, accessToken, realmName, userID, condition)
+		assert.Nil(t, err)
+		var accreds = kcUser.GetAttribute(constants.AttrbAccreditations)
+		assert.Equal(t, 3, count)
+		assert.Len(t, accreds, 3)
+		assert.Contains(t, accreds[0], "SHADOW1")
+		assert.Contains(t, accreds[1], "SHADOW3")
+		assert.Contains(t, accreds[2], "SHADOW5")
+		assert.Contains(t, accreds[0], validation.AddLargeDuration(time.Now(), duration1).Format(dateLayout))
+		assert.Contains(t, accreds[1], validation.AddLargeDuration(time.Now(), duration2).Format(dateLayout))
+		assert.Contains(t, accreds[2], validation.AddLargeDuration(time.Now(), duration3).Format(dateLayout))
+	})
+}

--- a/internal/keycloakb/datehelpers.go
+++ b/internal/keycloakb/datehelpers.go
@@ -7,6 +7,7 @@ import (
 
 	errorhandler "github.com/cloudtrust/common-service/errors"
 	stats_api "github.com/cloudtrust/keycloak-bridge/api/statistics"
+	"github.com/cloudtrust/keycloak-bridge/internal/constants"
 	msg "github.com/cloudtrust/keycloak-bridge/internal/constants"
 )
 
@@ -45,4 +46,17 @@ func NextMonth(ref time.Time) time.Time {
 		month = time.Month(int(month) + 1)
 	}
 	return time.Date(year, month, 1, 0, 0, 0, 0, ref.Location()).UTC()
+}
+
+// IsDateInThePast tells if a date is in the past or not
+func IsDateInThePast(value *string) *bool {
+	if value == nil {
+		return nil
+	}
+	var date, err = time.Parse(constants.SupportedDateLayouts[0], *value)
+	if err != nil {
+		return nil
+	}
+	var expired = date.Before(time.Now())
+	return &expired
 }

--- a/internal/keycloakb/datehelpers_test.go
+++ b/internal/keycloakb/datehelpers_test.go
@@ -106,3 +106,21 @@ func TestNextMonth(t *testing.T) {
 	assert.Equal(t, nextMonthIndia, NextMonth(reference.In(locIndia)))
 	assert.Equal(t, nextMonthCookIsland, NextMonth(reference.In(locCookIsland)))
 }
+
+func TestIsDateInThePast(t *testing.T) {
+	t.Run("Nil value", func(t *testing.T) {
+		assert.Nil(t, IsDateInThePast(nil))
+	})
+	t.Run("Invalid value", func(t *testing.T) {
+		var date = "32.13.2049"
+		assert.Nil(t, IsDateInThePast(&date))
+	})
+	t.Run("Date in the past", func(t *testing.T) {
+		var date = "01.01.2010"
+		assert.True(t, *IsDateInThePast(&date))
+	})
+	t.Run("Date in the future", func(t *testing.T) {
+		var date = "31.12.2100"
+		assert.False(t, *IsDateInThePast(&date))
+	})
+}

--- a/internal/keycloakb/mock_test.go
+++ b/internal/keycloakb/mock_test.go
@@ -1,6 +1,6 @@
 package keycloakb
 
 //go:generate mockgen -destination=./mock/instrumenting.go -package=mock -mock_names=Histogram=Histogram github.com/cloudtrust/common-service/metrics Histogram
-//go:generate mockgen -destination=./mock/configdbinstrumenting.go -package=mock -mock_names=ConfigurationDBModule=ConfigurationDBModule github.com/cloudtrust/keycloak-bridge/internal/keycloakb ConfigurationDBModule
+//go:generate mockgen -destination=./mock/configdbinstrumenting.go -package=mock -mock_names=ConfigurationDBModule=ConfigurationDBModule,AccredsKeycloakClient=AccredsKeycloakClient github.com/cloudtrust/keycloak-bridge/internal/keycloakb ConfigurationDBModule,AccredsKeycloakClient
 //go:generate mockgen -destination=./mock/keycloak_client.go -package=mock -mock_names=KeycloakClient=KeycloakClient github.com/cloudtrust/keycloak-bridge/internal/keycloakb KeycloakClient
 //go:generate mockgen -destination=./mock/sqltypes.go -package=mock -mock_names=CloudtrustDB=CloudtrustDB,SQLRow=SQLRow,SQLRows=SQLRows github.com/cloudtrust/common-service/database/sqltypes CloudtrustDB,SQLRow,SQLRows

--- a/pkg/kyc/mock_test.go
+++ b/pkg/kyc/mock_test.go
@@ -3,3 +3,4 @@ package kyc
 //go:generate mockgen -destination=./mock/kyc.go -package=mock -mock_names=Component=Component,KeycloakClient=KeycloakClient,EventsDBModule=EventsDBModule,UsersDBModule=UsersDBModule github.com/cloudtrust/keycloak-bridge/pkg/kyc Component,KeycloakClient,EventsDBModule,UsersDBModule
 //go:generate mockgen -destination=./mock/sqltypes.go -package=mock -mock_names=SQLRow=SQLRow,Transaction=Transaction github.com/cloudtrust/common-service/database/sqltypes SQLRow,Transaction
 //go:generate mockgen -destination=./mock/security.go -package=mock -mock_names=AuthorizationManager=AuthorizationManager github.com/cloudtrust/common-service/security AuthorizationManager
+//go:generate mockgen -destination=./mock/internal.go -package=mock -mock_names=AccreditationsModule=AccreditationsModule github.com/cloudtrust/keycloak-bridge/internal/keycloakb AccreditationsModule

--- a/pkg/statistics/component_test.go
+++ b/pkg/statistics/component_test.go
@@ -210,29 +210,28 @@ func TestGetStatisticsAuthenticationsLog(t *testing.T) {
 	ctx = context.WithValue(ctx, cs.CtContextRealm, realm)
 
 	var resExpected = []api.StatisticsConnectionRepresentation{
-		{"123", "LOGON_OK", "user", "127.0.0.1"},
+		{Date: "01.02.2003", Result: "LOGON_OK", User: "user", IP: "127.0.0.1"},
 	}
 
-	{ // fails
+	t.Run("fails", func(t *testing.T) {
 		mockDBModule.EXPECT().GetLastConnections(ctx, realm, "9").Return([]api.StatisticsConnectionRepresentation{}, errors.New("error")).Times(1)
 		res, err := component.GetStatisticsAuthenticationsLog(ctx, realm, "9")
 		assert.NotNil(t, err)
 		assert.Nil(t, res)
-	}
-
-	{ // success
+	})
+	t.Run("success", func(t *testing.T) {
 		mockDBModule.EXPECT().GetLastConnections(ctx, realm, "9").Return(resExpected, nil).Times(1)
 		res, err := component.GetStatisticsAuthenticationsLog(ctx, realm, "9")
 
 		assert.Nil(t, err)
 		assert.Equal(t, resExpected, res)
-	}
-	{ // fails - invalid param max
+	})
+	t.Run("fails - invalid param max", func(t *testing.T) {
 		res, err := component.GetStatisticsAuthenticationsLog(ctx, realm, "101")
 
 		assert.NotNil(t, err)
 		assert.Nil(t, res)
-	}
+	})
 }
 
 func TestGetActions(t *testing.T) {

--- a/pkg/validation/mock_test.go
+++ b/pkg/validation/mock_test.go
@@ -2,3 +2,4 @@ package validation
 
 //go:generate mockgen -destination=./mock/component.go -package=mock -mock_names=Component=Component,KeycloakClient=KeycloakClient,TokenProvider=TokenProvider,EventsDBModule=EventsDBModule,UsersDBModule=UsersDBModule github.com/cloudtrust/keycloak-bridge/pkg/validation Component,KeycloakClient,TokenProvider,EventsDBModule,UsersDBModule
 //go:generate mockgen -destination=./mock/security.go -package=mock -mock_names=AuthorizationManager=AuthorizationManager github.com/cloudtrust/common-service/security AuthorizationManager
+//go:generate mockgen -destination=./mock/internal.go -package=mock -mock_names=AccreditationsModule=AccreditationsModule github.com/cloudtrust/keycloak-bridge/internal/keycloakb AccreditationsModule


### PR DESCRIPTION
User accreditations are updated in /kyc and /validation
Accreditations are sent through the "GetUser" API of /kyc, /management and /users