### PR TITLE
CLOUDTRUST-2378 AJAX headers

### DIFF
--- a/configs/keycloak_bridge.yml
+++ b/configs/keycloak_bridge.yml
@@ -30,6 +30,8 @@ cors-allowed-headers:
   - "Authorization"
   - "Content-Type"
   - "X-Correlation-Id"
+  - "Cache-Control"
+  - "Pragma"
 cors-exposed-headers:
   - "Location"
   - "X-Correlation-Id"


### PR DESCRIPTION
These headers are needed to tell IE11 that he should NOT cache AJAX requests...