### PR TITLE
[CLOUDTRUST-3408] Don't leak information that email already exists on registering

### DIFF
--- a/api/register/swagger-api_register.yaml
+++ b/api/register/swagger-api_register.yaml
@@ -29,12 +29,8 @@ paths:
             schema:
               $ref: '#/components/schemas/User'
       responses:
-        200:
-          description: Successful operation. Returns the generated username
-          content:
-            application/json:
-              schema:
-                type: string
+        204:
+          description: Successful operation
         400:
           description: Invalid information provided
         403:
@@ -59,12 +55,8 @@ paths:
             schema:
               $ref: '#/components/schemas/User'
       responses:
-        200:
-          description: Successful operation. Returns the generated username
-          content:
-            application/json:
-              schema:
-                type: string
+        204:
+          description: Successful operation
         400:
           description: Invalid information provided
         403:

--- a/internal/constants/errormessages.go
+++ b/internal/constants/errormessages.go
@@ -13,7 +13,6 @@ const (
 	MsgErrCannotSaveConfigInDB = "cannotSaveConfigInDB"
 	MsgErrCannotUpdate         = "cannotUpdate"
 	MsgErrAlreadyOnboardedUser = "alreadyOnboardedUser"
-	MsgErrCantRegister         = "cantRegister"
 	MsgErrUnknown              = "unknowError"
 	MsgErrNotConfigured        = "notConfigured"
 	MsgErrUnverified           = "unverifiedFlag"

--- a/pkg/register/authorization.go
+++ b/pkg/register/authorization.go
@@ -108,7 +108,7 @@ func MakeAuthorizationRegisterComponentMW(logger log.Logger) func(Component) Com
 }
 
 // authorizationComponentMW implements Component.
-func (c *authorizationComponentMW) RegisterUser(ctx context.Context, targetRealmName, configRealmName string, user apiregister.UserRepresentation) (string, error) {
+func (c *authorizationComponentMW) RegisterUser(ctx context.Context, targetRealmName, configRealmName string, user apiregister.UserRepresentation) error {
 	return c.next.RegisterUser(ctx, targetRealmName, configRealmName, user)
 }
 

--- a/pkg/register/authorization_test.go
+++ b/pkg/register/authorization_test.go
@@ -107,8 +107,8 @@ func TestMakeAuthorizationRegisterComponentMW(t *testing.T) {
 	var user = apiregister.UserRepresentation{}
 	var expectedErr = errors.New("")
 
-	mockComponent.EXPECT().RegisterUser(ctx, socialRealm, realm, user).Return("", expectedErr).Times(1)
-	var _, err = component.RegisterUser(ctx, socialRealm, realm, user)
+	mockComponent.EXPECT().RegisterUser(ctx, socialRealm, realm, user).Return(expectedErr).Times(1)
+	var err = component.RegisterUser(ctx, socialRealm, realm, user)
 	assert.Equal(t, expectedErr, err)
 
 	mockComponent.EXPECT().GetConfiguration(ctx, realm).Return(apiregister.ConfigurationRepresentation{}, expectedErr).Times(1)

--- a/pkg/register/endpoint.go
+++ b/pkg/register/endpoint.go
@@ -2,9 +2,11 @@ package register
 
 import (
 	"context"
+	"net/http"
 
 	cs "github.com/cloudtrust/common-service"
 	commonerrors "github.com/cloudtrust/common-service/errors"
+	commonhttp "github.com/cloudtrust/common-service/http"
 	apiregister "github.com/cloudtrust/keycloak-bridge/api/register"
 	msg "github.com/cloudtrust/keycloak-bridge/internal/constants"
 	"github.com/go-kit/kit/endpoint"
@@ -16,6 +18,10 @@ type Endpoints struct {
 	RegisterCorpUser endpoint.Endpoint
 	GetConfiguration endpoint.Endpoint
 }
+
+var (
+	respNoContent = commonhttp.GenericResponse{StatusCode: http.StatusNoContent}
+)
 
 // MakeRegisterUserEndpoint endpoint creation
 func MakeRegisterUserEndpoint(component Component, socialRealm string) cs.Endpoint {
@@ -48,10 +54,14 @@ func registerUser(ctx context.Context, component Component, corpRealm string, re
 	// Validate input request
 	err = user.Validate(isSocialRealm)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return component.RegisterUser(ctx, corpRealm, realm, user)
+	err = component.RegisterUser(ctx, corpRealm, realm, user)
+	if err != nil {
+		return nil, err
+	}
+	return respNoContent, nil
 }
 
 // MakeGetConfigurationEndpoint endpoint creation

--- a/pkg/register/endpoint_test.go
+++ b/pkg/register/endpoint_test.go
@@ -55,7 +55,7 @@ func TestMakeRegisterUserEndpoint(t *testing.T) {
 		var socialRealm = "realm-123456"
 		m[prmRealm] = realm
 		m[reqBody] = string(bytes)
-		mockRegisterComponent.EXPECT().RegisterUser(gomock.Any(), socialRealm, realm, user).Return("", nil).Times(1)
+		mockRegisterComponent.EXPECT().RegisterUser(gomock.Any(), socialRealm, realm, user).Return(nil).Times(1)
 		_, err := MakeRegisterUserEndpoint(mockRegisterComponent, socialRealm)(context.Background(), m)
 		assert.Nil(t, err)
 	})
@@ -77,7 +77,7 @@ func TestMakeRegisterUserEndpoint(t *testing.T) {
 		m[prmCorpRealm] = socialRealm
 		var bytes, _ = json.Marshal(user)
 		m[reqBody] = string(bytes)
-		mockRegisterComponent.EXPECT().RegisterUser(gomock.Any(), socialRealm, socialRealm, user).Return("", nil).Times(1)
+		mockRegisterComponent.EXPECT().RegisterUser(gomock.Any(), socialRealm, socialRealm, user).Return(nil).Times(1)
 		_, err := MakeRegisterCorpUserEndpoint(mockRegisterComponent)(context.Background(), m)
 		assert.Nil(t, err)
 	})


### PR DESCRIPTION
I choosed to return a random username... but we can choose to return a constant username (ex: 00000000) or the actual username. Every solution leaks an information. We also can choose to stop returning the username which is not used by our front-end (but can be used by other GUI).