### PR TITLE
[CLOUDTRUST-3743] Fix default admin configuration with default map for Available checks

### DIFF
--- a/api/management/api.go
+++ b/api/management/api.go
@@ -611,6 +611,8 @@ func ConvertRealmAdminConfigurationFromDBStruct(conf configuration.RealmAdminCon
 	var checks = conf.AvailableChecks
 	if checks == nil {
 		checks = make(map[string]bool)
+		checks[configuration.CheckKeyIDNow] = false
+		checks[configuration.CheckKeyPhysical] = false
 	}
 	return RealmAdminConfiguration{
 		Mode:                     defaultString(conf.Mode, "corporate"),

--- a/api/management/api_test.go
+++ b/api/management/api_test.go
@@ -447,7 +447,7 @@ func TestConvertRealmAdminConfiguration(t *testing.T) {
 		var config = configuration.RealmAdminConfiguration{}
 		var res = ConvertRealmAdminConfigurationFromDBStruct(config)
 		assert.Equal(t, "corporate", *res.Mode)
-		assert.Len(t, res.AvailableChecks, 0)
+		assert.Len(t, res.AvailableChecks, 2)
 		assert.Len(t, res.Accreditations, 0)
 		assert.False(t, *res.SelfRegisterEnabled)
 		assert.False(t, *res.ShowGlnEditing)


### PR DESCRIPTION
Add an default map for available checks
Adapt 1 test in in api_test.go to take the change into account