### PR TITLE
[CLOUDTRUST-5515] Allow more inputs for advanced search

### DIFF
--- a/internal/constants/regexp.go
+++ b/internal/constants/regexp.go
@@ -22,7 +22,6 @@ const (
 	RegExpEmail               = `^.+\@.+\..+$`
 	RegExpNameSpecialChars    = `^([\p{Lu}\p{Ll}][\p{Lu}\p{Ll} /\\\.',-]{0,49})$`
 	RegExpNameSpecialChars128 = `^([\p{Lu}\p{Ll}][\p{Lu}\p{Ll} /\\\.',-]{0,127})$`
-	RegExpLastNameSearch      = `^[=%]?([\p{Lu}\p{Ll}][\p{Lu}\p{Ll} /\\\.'-]{0,127}[%]?)$`
 	RegExpPhoneNumber         = `^\+[1-9]\d{1,14}$`
 	RegExpLabel               = regExpLen255
 	RegExpGender              = `^[MFU]$`
@@ -55,7 +54,7 @@ const (
 	RegExpCustomValue = `^[A-Za-z\d_-]{0,50}$`
 	RegExpTxnID       = regExpLen255
 
-	//Corporate Regex TO CLEAN WHEN WE WILL HAVE ATTRIBUTE MANAGEMENT
+	// Corporate Regex TO CLEAN WHEN WE WILL HAVE ATTRIBUTE MANAGEMENT
 	regExpLen128OrEmpty      = `^.{0,128}$`
 	RegExpCorporateFirstName = regExpLen128OrEmpty
 	RegExpCorporateLastName  = regExpLen128

--- a/pkg/management/http.go
+++ b/pkg/management/http.go
@@ -68,7 +68,7 @@ func MakeManagementHandler(e endpoint.Endpoint, logger log.Logger) *http_transpo
 
 // decodeEventsRequest gets the HTTP parameters and body content
 func decodeManagementRequest(ctx context.Context, req *http.Request) (interface{}, error) {
-	var pathParams = map[string]string{
+	pathParams := map[string]string{
 		prmRealm:        constants.RegExpRealmName,
 		prmUserID:       constants.RegExpID,
 		prmClientID:     constants.RegExpClientID,
@@ -79,11 +79,11 @@ func decodeManagementRequest(ctx context.Context, req *http.Request) (interface{
 		prmAction:       constants.RegExpName,
 	}
 
-	var queryParams = map[string]string{
-		prmQryEmail:         constants.RegExpEmail,
+	queryParams := map[string]string{
+		prmQryEmail:         constants.RegExpSearch,
 		prmQryFirstName:     constants.RegExpSearch,
-		prmQryLastName:      constants.RegExpLastNameSearch,
-		prmQryUserName:      constants.RegExpUsername,
+		prmQryLastName:      constants.RegExpSearch,
+		prmQryUserName:      constants.RegExpSearch,
 		prmQrySearch:        constants.RegExpSearch,
 		prmQryClientID:      constants.RegExpClientID,
 		prmQryRedirectURI:   constants.RegExpRedirectURI,

--- a/pkg/management/http.go
+++ b/pkg/management/http.go
@@ -68,7 +68,7 @@ func MakeManagementHandler(e endpoint.Endpoint, logger log.Logger) *http_transpo
 
 // decodeEventsRequest gets the HTTP parameters and body content
 func decodeManagementRequest(ctx context.Context, req *http.Request) (interface{}, error) {
-	pathParams := map[string]string{
+	var pathParams = map[string]string{
 		prmRealm:        constants.RegExpRealmName,
 		prmUserID:       constants.RegExpID,
 		prmClientID:     constants.RegExpClientID,
@@ -79,7 +79,7 @@ func decodeManagementRequest(ctx context.Context, req *http.Request) (interface{
 		prmAction:       constants.RegExpName,
 	}
 
-	queryParams := map[string]string{
+	var queryParams = map[string]string{
 		prmQryEmail:         constants.RegExpSearch,
 		prmQryFirstName:     constants.RegExpSearch,
 		prmQryLastName:      constants.RegExpSearch,

--- a/pkg/management/http_test.go
+++ b/pkg/management/http_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	errorhandler "github.com/cloudtrust/common-service/v2/errors"
@@ -80,7 +81,7 @@ func TestHTTPManagementHandler(t *testing.T) {
 		assert.Equal(t, email, resp["email"])
 	})
 	t.Run("Invalid input parameter", func(t *testing.T) {
-		res, err := http.Get(ts.URL + "/realms/master?email=not_an_email")
+		res, err := http.Get(ts.URL + "/realms/master?email=" + strings.Repeat("A", 129))
 		assert.Nil(t, err)
 		assert.Equal(t, http.StatusBadRequest, res.StatusCode)
 	})


### PR DESCRIPTION
Keycloak-bridge used to deny and return an invalid parameter error if we search for usernames, first/last names, or emails that do not satisfy a RegExp. This is not the behavior we intend as it may be useful to search for an address containing a substring.