### PR TITLE
[CLOUDTRUST-5511] Remove onboarding status on user creation

### DIFF
--- a/api/management/api.go
+++ b/api/management/api.go
@@ -52,7 +52,6 @@ type UserRepresentation struct {
 	NameID                *string                        `json:"nameId,omitempty"`
 	OnboardingCompleted   *bool                          `json:"onboardingCompleted,omitempty"`
 	CreatedTimestamp      *int64                         `json:"createdTimestamp,omitempty"`
-	OnboardingStatus      *string                        `json:"onboardingStatus,omitempty"`
 }
 
 // UpdatableUserRepresentation struct
@@ -85,7 +84,6 @@ type UpdatableUserRepresentation struct {
 	PendingChecks        *[]string                      `json:"pendingChecks,omitempty"`
 	Accreditations       *[]AccreditationRepresentation `json:"accreditations,omitempty"`
 	CreatedTimestamp     *int64                         `json:"createdTimestamp,omitempty"`
-	OnboardingStatus     *string                        `json:"onboardingStatus,omitempty"`
 }
 
 // UserCheck is a representation of a user check
@@ -399,7 +397,6 @@ func ConvertToAPIUser(ctx context.Context, userKc kc.UserRepresentation, logger 
 	userRep.IDDocumentNumber = userKc.GetAttributeString(constants.AttrbIDDocumentNumber)
 	userRep.IDDocumentExpiration = userKc.GetAttributeString(constants.AttrbIDDocumentExpiration)
 	userRep.IDDocumentCountry = userKc.GetAttributeString(constants.AttrbIDDocumentCountry)
-	userRep.OnboardingStatus = userKc.GetAttributeString(constants.AttrbOnboardingStatus)
 
 	if value, err := userKc.GetAttributeBool(constants.AttrbPhoneNumberVerified); err == nil && value != nil {
 		userRep.PhoneNumberVerified = value
@@ -480,7 +477,6 @@ func ConvertToKCUser(user UserRepresentation) kc.UserRepresentation {
 	attributes.SetStringWhenNotNil(constants.AttrbIDDocumentNumber, user.IDDocumentNumber)
 	attributes.SetStringWhenNotNil(constants.AttrbIDDocumentExpiration, user.IDDocumentExpiration)
 	attributes.SetStringWhenNotNil(constants.AttrbIDDocumentCountry, user.IDDocumentCountry)
-	attributes.SetStringWhenNotNil(constants.AttrbOnboardingStatus, user.OnboardingStatus)
 
 	if len(attributes) > 0 {
 		userRep.Attributes = &attributes
@@ -520,8 +516,6 @@ func MergeUpdatableUserWithoutEmailAndPhoneNumber(target *kc.UserRepresentation,
 	attributes.SetStringWhenNotNil(constants.AttrbIDDocumentNumber, user.IDDocumentNumber)
 	attributes.SetStringWhenNotNil(constants.AttrbIDDocumentExpiration, user.IDDocumentExpiration)
 	attributes.SetStringWhenNotNil(constants.AttrbIDDocumentCountry, user.IDDocumentCountry)
-	attributes.SetStringWhenNotNil(constants.AttrbOnboardingStatus, user.OnboardingStatus)
-
 	if user.BusinessID.Defined {
 		attributes.SetStringWhenNotNil(constants.AttrbBusinessID, user.BusinessID.Value)
 	}
@@ -834,8 +828,6 @@ func (user *UserRepresentation) GetField(field string) interface{} {
 		return profile.IfNotNil(user.Locale)
 	case fields.BusinessID.AttributeName():
 		return profile.IfNotNil(user.BusinessID)
-	case fields.OnboardingStatus.AttributeName():
-		return profile.IfNotNil(user.OnboardingStatus)
 	default:
 		return nil
 	}
@@ -888,9 +880,6 @@ func (user *UserRepresentation) SetField(field string, value interface{}) {
 		break
 	case fields.BusinessID.AttributeName():
 		user.BusinessID = cs.ToStringPtr(value)
-		break
-	case fields.OnboardingStatus.AttributeName():
-		user.OnboardingStatus = cs.ToStringPtr(value)
 		break
 	}
 }
@@ -949,8 +938,6 @@ func (user *UpdatableUserRepresentation) GetField(field string) interface{} {
 		return profile.IfNotNil(user.Locale)
 	case fields.BusinessID.AttributeName():
 		return toOptionalStringPtr(user.BusinessID)
-	case fields.OnboardingStatus.AttributeName():
-		return profile.IfNotNil(user.OnboardingStatus)
 	default:
 		return nil
 	}
@@ -1028,9 +1015,6 @@ func (user *UpdatableUserRepresentation) SetField(field string, value interface{
 			user.BusinessID.Defined = true
 			user.BusinessID.Value = cs.ToStringPtr(value)
 		}
-		break
-	case fields.OnboardingStatus.AttributeName():
-		user.OnboardingStatus = cs.ToStringPtr(value)
 		break
 	}
 }

--- a/api/register/api.go
+++ b/api/register/api.go
@@ -36,7 +36,6 @@ type UserRepresentation struct {
 	IDDocumentCountry    *string `json:"idDocumentCountry,omitempty"`
 	Locale               *string `json:"locale,omitempty"`
 	BusinessID           *string `json:"businessId,omitempty"`
-	OnboardingStatus     *string `json:"onboardingStatus,omitempty"`
 }
 
 // ConfigurationRepresentation representation
@@ -85,7 +84,6 @@ func (u *UserRepresentation) ConvertToKeycloak() kc.UserRepresentation {
 	attributes.SetStringWhenNotNil(constants.AttrbIDDocumentNumber, u.IDDocumentNumber)
 	attributes.SetStringWhenNotNil(constants.AttrbIDDocumentExpiration, u.IDDocumentExpiration)
 	attributes.SetStringWhenNotNil(constants.AttrbIDDocumentCountry, u.IDDocumentCountry)
-	attributes.SetStringWhenNotNil(constants.AttrbOnboardingStatus, u.OnboardingStatus)
 
 	return kc.UserRepresentation{
 		Username:      u.Username,
@@ -140,8 +138,6 @@ func (u *UserRepresentation) GetField(field string) interface{} {
 		return profile.IfNotNil(u.Locale)
 	case fields.BusinessID.AttributeName():
 		return profile.IfNotNil(u.BusinessID)
-	case fields.OnboardingStatus.AttributeName():
-		return profile.IfNotNil(u.OnboardingStatus)
 	default:
 		return nil
 	}
@@ -194,9 +190,6 @@ func (u *UserRepresentation) SetField(field string, value interface{}) {
 		break
 	case fields.BusinessID.AttributeName():
 		u.BusinessID = cs.ToStringPtr(value)
-		break
-	case fields.OnboardingStatus.AttributeName():
-		u.OnboardingStatus = cs.ToStringPtr(value)
 		break
 	}
 }

--- a/internal/constants/keycloak.go
+++ b/internal/constants/keycloak.go
@@ -37,5 +37,4 @@ var (
 	AttrbIDDocumentNumber      = kc.AttributeKey(fields.IDDocumentNumber.AttributeName())
 	AttrbIDDocumentExpiration  = kc.AttributeKey(fields.IDDocumentExpiration.AttributeName())
 	AttrbIDDocumentCountry     = kc.AttributeKey(fields.IDDocumentCountry.AttributeName())
-	AttrbOnboardingStatus      = kc.AttributeKey(fields.OnboardingStatus.AttributeName())
 )

--- a/pkg/management/component.go
+++ b/pkg/management/component.go
@@ -35,8 +35,7 @@ const (
 	actionVerifyEmail       = "ct-verify-email"
 	actionVerifyPhoneNumber = "mobilephone-validation"
 
-	managementOnboardingStatus = "user-created-by-api"
-	eventCredentialID          = "credential_id"
+	eventCredentialID = "credential_id"
 )
 
 // KeycloakClient are methods from keycloak-client used by this component
@@ -391,7 +390,6 @@ func (c *component) genericCreateUser(ctx context.Context, accessToken string, c
 	user api.UserRepresentation, generateUsername bool, generateNameID bool, termsOfUse bool, useOnboardingCheckForExistingUser bool) (string, error) {
 	var userRep = api.ConvertToKCUser(user)
 	userRep.SetAttributeString(constants.AttrbSource, source)
-	userRep.SetAttributeString(constants.AttrbOnboardingStatus, managementOnboardingStatus)
 
 	if termsOfUse {
 		var reqActions []string

--- a/pkg/management/component_test.go
+++ b/pkg/management/component_test.go
@@ -468,8 +468,6 @@ func TestCreateUser(t *testing.T) {
 
 	var attrbs = make(kc.Attributes)
 	attrbs[constants.AttrbSource] = []string{"api"}
-	attrbs[constants.AttrbOnboardingStatus] = []string{"user-created-by-api"}
-
 	t.Run("Create with minimum properties", func(t *testing.T) {
 		var kcUserRep = kc.UserRepresentation{
 			Username:   &username,
@@ -513,8 +511,6 @@ func TestCreateUser(t *testing.T) {
 		var idDocumentExpiration = "23.12.2019"
 		var idDocumentCountry = "IT"
 
-		var onboardingStatus = "user-created-by-api"
-
 		mocks.keycloakClient.EXPECT().CreateUser(accessToken, realmName, targetRealmName, gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 			func(accessToken, realmName, targetRealmName string, kcUserRep kc.UserRepresentation, _ ...interface{}) (string, error) {
 				assert.Equal(t, username, *kcUserRep.Username)
@@ -530,7 +526,6 @@ func TestCreateUser(t *testing.T) {
 				assert.Equal(t, gender, *kcUserRep.GetAttributeString(constants.AttrbGender))
 				assert.Equal(t, birthDate, *kcUserRep.GetAttributeString(constants.AttrbBirthDate))
 				assert.Equal(t, locale, *kcUserRep.GetAttributeString(constants.AttrbLocale))
-				assert.Equal(t, onboardingStatus, *kcUserRep.GetAttributeString(constants.AttrbOnboardingStatus))
 				return locationURL, nil
 			})
 
@@ -704,7 +699,6 @@ func TestGetUser(t *testing.T) {
 		var idDocumentNumber = "1234-4567-VD-3"
 		var idDocumentExpiration = "23.12.2019"
 		var idDocumentCountry = "MX"
-		var onboardingStatus = "user-created-by-api"
 
 		var attributes = make(kc.Attributes)
 		attributes.SetString(constants.AttrbPhoneNumber, phoneNumber)
@@ -720,7 +714,6 @@ func TestGetUser(t *testing.T) {
 		attributes.SetString(constants.AttrbIDDocumentNumber, idDocumentNumber)
 		attributes.SetString(constants.AttrbIDDocumentExpiration, idDocumentExpiration)
 		attributes.SetString(constants.AttrbIDDocumentCountry, idDocumentCountry)
-		attributes.SetString(constants.AttrbOnboardingStatus, onboardingStatus)
 
 		var kcUserRep = kc.UserRepresentation{
 			ID:               &id,
@@ -772,7 +765,6 @@ func TestGetUser(t *testing.T) {
 		assert.Equal(t, idDocumentNumber, *apiUserRep.IDDocumentNumber)
 		assert.Equal(t, idDocumentType, *apiUserRep.IDDocumentType)
 		assert.Equal(t, idDocumentCountry, *apiUserRep.IDDocumentCountry)
-		assert.Equal(t, onboardingStatus, *apiUserRep.OnboardingStatus)
 	})
 
 	t.Run("Get user with succces with empty user info", func(t *testing.T) {
@@ -850,7 +842,6 @@ func TestGetUser(t *testing.T) {
 		assert.Nil(t, apiUserRep.IDDocumentNumber)
 		assert.Nil(t, apiUserRep.IDDocumentType)
 		assert.Nil(t, apiUserRep.IDDocumentCountry)
-		assert.Nil(t, apiUserRep.OnboardingStatus)
 	})
 
 	t.Run("Retrieve checks fails", func(t *testing.T) {

--- a/pkg/register/component.go
+++ b/pkg/register/component.go
@@ -18,8 +18,6 @@ import (
 	"github.com/cloudtrust/keycloak-client/v2/toolbox"
 )
 
-const registerOnboardingStatus = "self-registration-form-completed"
-
 // KeycloakClient are methods from keycloak-client used by this component
 type KeycloakClient interface {
 	GetRealm(accessToken string, realmName string) (kc.RealmRepresentation, error)
@@ -321,9 +319,6 @@ func (c *component) createUser(ctx context.Context, accessToken string, realmNam
 		return kc.UserRepresentation{}, err
 	}
 	kcUser.Groups = &groupIDs
-
-	// Set onboarding status
-	kcUser.SetAttributeString(constants.AttrbOnboardingStatus, registerOnboardingStatus)
 
 	_, err = c.onboardingModule.CreateUser(ctx, accessToken, realmName, realmName, &kcUser, false)
 	if err != nil {

--- a/pkg/register/component_test.go
+++ b/pkg/register/component_test.go
@@ -20,21 +20,20 @@ import (
 
 func createValidUser() apiregister.UserRepresentation {
 	var (
-		gender           = "M"
-		firstName        = "Marc"
-		lastName         = "El-Bichoun"
-		email            = "marcel.bichon@elca.ch"
-		phoneNumber      = "00 33 686 550011"
-		birthDate        = "31.03.2001"
-		birthLocation    = "Montreux"
-		nationality      = "CH"
-		docType          = "ID_CARD"
-		docNumber        = "MEL123789654ABC"
-		docExp           = "28.02.2050"
-		docCountry       = "AT"
-		locale           = "fr"
-		gln              = "123456789"
-		onboardingStatus = "self-registration-form-completed"
+		gender        = "M"
+		firstName     = "Marc"
+		lastName      = "El-Bichoun"
+		email         = "marcel.bichon@elca.ch"
+		phoneNumber   = "00 33 686 550011"
+		birthDate     = "31.03.2001"
+		birthLocation = "Montreux"
+		nationality   = "CH"
+		docType       = "ID_CARD"
+		docNumber     = "MEL123789654ABC"
+		docExp        = "28.02.2050"
+		docCountry    = "AT"
+		locale        = "fr"
+		gln           = "123456789"
 	)
 
 	return apiregister.UserRepresentation{
@@ -52,7 +51,6 @@ func createValidUser() apiregister.UserRepresentation {
 		IDDocumentCountry:    &docCountry,
 		Locale:               &locale,
 		BusinessID:           &gln,
-		OnboardingStatus:     &onboardingStatus,
 	}
 }
 
@@ -253,7 +251,6 @@ func TestRegisterUser(t *testing.T) {
 		mocks.onboardingModule.EXPECT().CreateUser(ctx, accessToken, targetRealmName, targetRealmName, gomock.Any(), false).DoAndReturn(
 			func(_, _, _, _ interface{}, kcUser *kc.UserRepresentation, _ interface{}) (string, error) {
 				assert.NotNil(t, kcUser.Attributes)
-				assert.Equal(t, "self-registration-form-completed", *kcUser.GetAttributeString(constants.AttrbOnboardingStatus))
 				return "", errors.New("unexpected error")
 			})
 
@@ -264,7 +261,6 @@ func TestRegisterUser(t *testing.T) {
 	mocks.onboardingModule.EXPECT().CreateUser(ctx, accessToken, targetRealmName, targetRealmName, gomock.Any(), false).DoAndReturn(
 		func(_, _, _, _ interface{}, kcUser *kc.UserRepresentation, _ interface{}) (string, error) {
 			assert.NotNil(t, kcUser.Attributes)
-			assert.Equal(t, "self-registration-form-completed", *kcUser.GetAttributeString(constants.AttrbOnboardingStatus))
 			var generatedUsername = "78564513"
 			kcUser.ID = &kcID
 			kcUser.Username = &generatedUsername


### PR DESCRIPTION
This rolls out the onboarding status set on user creation as it will be part of release 7.6.