### PR TITLE
[CLOUDTRUST-5782] Make identification URI endpoint return an error for an empty URI

### DIFF
--- a/api/configuration/swagger-api_configuration.yaml
+++ b/api/configuration/swagger-api_configuration.yaml
@@ -4,7 +4,7 @@ info:
   description: 'Configuration API for Cloudtrust.'
   version: 1.0.0
 servers:
-- url: http://localhost:8833
+- url: http://localhost:8870
 paths:
   /configuration/realms/{realm}/identification:
     get:

--- a/pkg/configuration/component.go
+++ b/pkg/configuration/component.go
@@ -37,9 +37,9 @@ func (c *component) GetIdentificationURI(ctx context.Context, realm string, cont
 		return "", errorhandler.CreateBadRequestError(errorhandler.MsgErrInvalidParam + ".realm-and-context-key")
 	}
 
-	if ctxOverride.IdentificationURI == nil {
+	if ctxOverride.IdentificationURI == nil || *ctxOverride.IdentificationURI == "" {
 		c.logger.Info(ctx, "msg", "Empty identification URI", "context-key", contextKey, "realm", realm)
-		return "", errorhandler.CreateNotFoundError(errorhandler.MsgErrInvalidParam + ".realm-and-context-key")
+		return "", errorhandler.CreateBadRequestError(errorhandler.MsgErrInvalidParam + ".realm-and-context-key")
 	}
 
 	return *ctxOverride.IdentificationURI, nil

--- a/pkg/configuration/component_test.go
+++ b/pkg/configuration/component_test.go
@@ -43,10 +43,21 @@ func TestGetIdentificationURI(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 
-	t.Run("Empty identification URI", func(t *testing.T) {
+	t.Run("No identification URI", func(t *testing.T) {
 		mocks.contextKeyMgr.EXPECT().GetOverride(realm, contextKey).Return(keycloakb.ContextKeyParameters{
 			ID:    ptr(contextKey),
 			Realm: &realm,
+		}, true)
+
+		_, err := component.GetIdentificationURI(context.Background(), realm, contextKey)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("Empty identification URI", func(t *testing.T) {
+		mocks.contextKeyMgr.EXPECT().GetOverride(realm, contextKey).Return(keycloakb.ContextKeyParameters{
+			ID:                ptr(contextKey),
+			Realm:             &realm,
+			IdentificationURI: ptr(""),
 		}, true)
 
 		_, err := component.GetIdentificationURI(context.Background(), realm, contextKey)

--- a/pkg/configuration/component_test.go
+++ b/pkg/configuration/component_test.go
@@ -45,8 +45,9 @@ func TestGetIdentificationURI(t *testing.T) {
 
 	t.Run("No identification URI", func(t *testing.T) {
 		mocks.contextKeyMgr.EXPECT().GetOverride(realm, contextKey).Return(keycloakb.ContextKeyParameters{
-			ID:    ptr(contextKey),
-			Realm: &realm,
+			ID:                ptr(contextKey),
+			Realm:             &realm,
+			IdentificationURI: nil,
 		}, true)
 
 		_, err := component.GetIdentificationURI(context.Background(), realm, contextKey)


### PR DESCRIPTION
I also fixed the swagger and the errors being thrown to fit what we wanted.