### PR TITLE
[CLOUDTRUST-6419] Add authz of IDP API to GetActions of Management API

### DIFF
--- a/pkg/management/component.go
+++ b/pkg/management/component.go
@@ -2135,7 +2135,7 @@ func (c *component) GetActions(ctx context.Context) ([]api.ActionRepresentation,
 
 	// The communications API and some tasks are published internally only.
 	// To be able to configure the rights from the BO we add them here.
-	for _, action := range security.Actions.GetActionsForAPIs(security.BridgeService, security.ManagementAPI, security.CommunicationAPI, security.TaskAPI) {
+	for _, action := range security.Actions.GetActionsForAPIs(security.BridgeService, security.ManagementAPI, security.CommunicationAPI, security.TaskAPI, security.IdpAPI) {
 		var name = action.Name
 		var scope = string(action.Scope)
 

--- a/pkg/management/component_test.go
+++ b/pkg/management/component_test.go
@@ -104,6 +104,11 @@ func TestGetActions(t *testing.T) {
 	checkPresence("COM_SendEmail", security.ScopeRealm)
 	checkPresence("COM_SendSMS", security.ScopeRealm)
 	checkPresence("TSK_DeleteDeniedToUUsers", security.ScopeGlobal)
+	checkPresence("IDP_GetIdentityProvider", security.ScopeRealm)
+	checkPresence("IDP_CreateIdentityProvider", security.ScopeRealm)
+	checkPresence("IDP_UpdateIdentityProvider", security.ScopeRealm)
+	checkPresence("IDP_DeleteIdentityProvider", security.ScopeRealm)
+
 }
 
 func TestGetRealms(t *testing.T) {


### PR DESCRIPTION
Added in Management API as usually done with other internal APIs (Tasks, Communications). A future JIRA will look into ways to improve this handling