### PR TITLE
[CLOUDTRUST-8511] Send notification revoked event with KC username

### DIFF
--- a/pkg/management/component.go
+++ b/pkg/management/component.go
@@ -613,7 +613,7 @@ func (c *component) UpdateUser(ctx context.Context, realmName, userID string, us
 	}
 	var ap, _ = keycloakb.NewAccreditationsProcessor(oldUserKc.GetFieldValues(fields.Accreditations))
 	ap.RevokeTypes(revokeAccreds, func(accred keycloakb.AccreditationRepresentation) {
-		c.reportAccreditationRevokedEvent(ctx, realmName, userID, *user.Username, accred)
+		c.reportAccreditationRevokedEvent(ctx, realmName, userID, *oldUserKc.Username, accred)
 	})
 	newAccreditations := ap.ToKeycloak()
 


### PR DESCRIPTION
The `*user.Username` made the username field mandatory in the UpdateUser payload (otherwise it panicked) and we don't want this